### PR TITLE
Make osd-window icon smaller on GNOME 42

### DIFF
--- a/src/gnome-shell/sass/widgets/_osd-42.scss
+++ b/src/gnome-shell/sass/widgets/_osd-42.scss
@@ -9,10 +9,11 @@ $osd_levelbar_height: 4px;
   spacing: $container_padding * 2; // 12px
   padding: $container_padding * 2 $container_padding * 3;
   & > * { spacing: 8px; }
-  margin-bottom: $container_margin;
+  margin-bottom: $container_margin * 16; // 32px
+  min-height: 24px;
 
   StIcon {
-    icon-size: 96px;
+    icon-size: 24px;
   }
 
   .osd-monitor-label { font-size: 3em; }

--- a/src/gnome-shell/shell-42-0/gnome-shell-Compact.css
+++ b/src/gnome-shell/shell-42-0/gnome-shell-Compact.css
@@ -1745,7 +1745,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   font-weight: bold;
   spacing: 8px;
   padding: 8px 12px;
-  margin-bottom: 2px;
+  margin-bottom: 32px;
+  min-height: 24px;
 }
 
 .osd-window > * {
@@ -1753,7 +1754,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .osd-window StIcon {
-  icon-size: 96px;
+  icon-size: 24px;
 }
 
 .osd-window .osd-monitor-label {

--- a/src/gnome-shell/shell-42-0/gnome-shell-Dark-Compact.css
+++ b/src/gnome-shell/shell-42-0/gnome-shell-Dark-Compact.css
@@ -1745,7 +1745,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   font-weight: bold;
   spacing: 8px;
   padding: 8px 12px;
-  margin-bottom: 2px;
+  margin-bottom: 32px;
+  min-height: 24px;
 }
 
 .osd-window > * {
@@ -1753,7 +1754,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .osd-window StIcon {
-  icon-size: 96px;
+  icon-size: 24px;
 }
 
 .osd-window .osd-monitor-label {

--- a/src/gnome-shell/shell-42-0/gnome-shell-Dark.css
+++ b/src/gnome-shell/shell-42-0/gnome-shell-Dark.css
@@ -1745,7 +1745,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   font-weight: bold;
   spacing: 12px;
   padding: 12px 18px;
-  margin-bottom: 4px;
+  margin-bottom: 64px;
+  min-height: 24px;
 }
 
 .osd-window > * {
@@ -1753,7 +1754,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .osd-window StIcon {
-  icon-size: 96px;
+  icon-size: 24px;
 }
 
 .osd-window .osd-monitor-label {

--- a/src/gnome-shell/shell-42-0/gnome-shell.css
+++ b/src/gnome-shell/shell-42-0/gnome-shell.css
@@ -1745,7 +1745,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   font-weight: bold;
   spacing: 12px;
   padding: 12px 18px;
-  margin-bottom: 4px;
+  margin-bottom: 64px;
+  min-height: 24px;
 }
 
 .osd-window > * {
@@ -1753,7 +1754,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .osd-window StIcon {
-  icon-size: 96px;
+  icon-size: 24px;
 }
 
 .osd-window .osd-monitor-label {


### PR DESCRIPTION
This changes the size of the osd-window and adds some margin-bottom on GNOME 42.

Before (Compact, Dark, Yellow)
![Screenshot from 2022-05-06 13-26-56](https://user-images.githubusercontent.com/1464877/167123160-37b4eee6-18fa-4792-ba2d-de83ee079b18.png)

After (Compact, Dark, Yellow)
![Screenshot from 2022-05-06 13-25-54](https://user-images.githubusercontent.com/1464877/167123151-828f953f-91e7-4b76-816d-1c66a1b07362.png)