### PR TITLE
Change Chromium button border color to a solid variant to fix window transparency

### DIFF
--- a/src/_sass/gtk/apps/_misc.scss
+++ b/src/_sass/gtk/apps/_misc.scss
@@ -76,7 +76,7 @@ window.background.chromium {
   // toolbar's border-bottom refers to button's border
   // FIXME: Chrome's button border ignores theme's alpha value :(
   entry,
-  > button { border: 1px solid $track; }
+  > button { border: 1px solid $titlebar-backdrop; }
 
   > button {
     color: $primary;

--- a/src/gtk/3.0/gtk-Compact.css
+++ b/src/gtk/3.0/gtk-Compact.css
@@ -7115,7 +7115,7 @@ window.background.chromium {
 
 window.background.chromium entry,
 window.background.chromium > button {
-  border: 1px solid rgba(0, 0, 0, 0.26);
+  border: 1px solid #2C2C2C;
 }
 
 window.background.chromium > button {

--- a/src/gtk/3.0/gtk-Dark-Compact.css
+++ b/src/gtk/3.0/gtk-Dark-Compact.css
@@ -7111,7 +7111,7 @@ window.background.chromium {
 
 window.background.chromium entry,
 window.background.chromium > button {
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  border: 1px solid #2C2C2C;
 }
 
 window.background.chromium > button {

--- a/src/gtk/3.0/gtk-Dark.css
+++ b/src/gtk/3.0/gtk-Dark.css
@@ -7111,7 +7111,7 @@ window.background.chromium {
 
 window.background.chromium entry,
 window.background.chromium > button {
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  border: 1px solid #2C2C2C;
 }
 
 window.background.chromium > button {

--- a/src/gtk/3.0/gtk-Light-Compact.css
+++ b/src/gtk/3.0/gtk-Light-Compact.css
@@ -7114,7 +7114,7 @@ window.background.chromium {
 
 window.background.chromium entry,
 window.background.chromium > button {
-  border: 1px solid rgba(0, 0, 0, 0.26);
+  border: 1px solid #FFFFFF;
 }
 
 window.background.chromium > button {

--- a/src/gtk/3.0/gtk-Light.css
+++ b/src/gtk/3.0/gtk-Light.css
@@ -7114,7 +7114,7 @@ window.background.chromium {
 
 window.background.chromium entry,
 window.background.chromium > button {
-  border: 1px solid rgba(0, 0, 0, 0.26);
+  border: 1px solid #FFFFFF;
 }
 
 window.background.chromium > button {

--- a/src/gtk/3.0/gtk.css
+++ b/src/gtk/3.0/gtk.css
@@ -7115,7 +7115,7 @@ window.background.chromium {
 
 window.background.chromium entry,
 window.background.chromium > button {
-  border: 1px solid rgba(0, 0, 0, 0.26);
+  border: 1px solid #2C2C2C;
 }
 
 window.background.chromium > button {


### PR DESCRIPTION
There is a pixel high transparent line between the bookmarks bar and the page content on Chromium-based browsers. I found that Materia also has this issue as well, but other GTK3 themes do not (like Adwaita).

I replaced `$track` with the `$titlebar-backdrop`  color for Chromium buttons.

Before:
![Screenshot from 2022-05-10 15-12-53](https://user-images.githubusercontent.com/1464877/167637755-3b38f840-c647-4dc1-9823-2279d58cbb9e.png)

After:
![Screenshot from 2022-05-10 15-13-51](https://user-images.githubusercontent.com/1464877/167637774-fdcae16b-e500-4bef-be5b-a5e01e3982ae.png)
