### PR TITLE
libadwaita link colors properly

### DIFF
--- a/core.sh
+++ b/core.sh
@@ -362,7 +362,7 @@ clean_theme() {
 
 link_theme() {
   for theme in "${themes[@]}"; do
-    for color in "${colors[2]}"; do
+    for color in "${colors[@]}"; do
       for size in "${sizes[0]}"; do
         link_libadwaita "${dest:-$DEST_DIR}" "${_name:-$THEME_NAME}" "$theme" "$color" "$size"
       done


### PR DESCRIPTION
when using ./install.sh -c light -l the link is created with the -dark theme color that does not exist, this will fix that issue and properly theme with the correct color choice