### PR TITLE
tweaking gnome-shell dialog sass to resolve Issue 227

### DIFF
--- a/src/gnome-shell/sass/widgets/_dialogs.scss
+++ b/src/gnome-shell/sass/widgets/_dialogs.scss
@@ -15,6 +15,7 @@ $mdborder_color: if($variant == 'light', rgba(black, 0.15), rgba(black, 0.75));
     margin: 32px 40px;
     spacing: 32px;
     max-width: 28em;
+    background-color: $base_color;
   }
 
   .modal-dialog-linked-button {
@@ -142,6 +143,7 @@ $mdborder_color: if($variant == 'light', rgba(black, 0.15), rgba(black, 0.75));
 
   .modal-dialog-content-box {
     margin-bottom: 24px;
+     background-color: $base_color;
   }
 }
 


### PR DESCRIPTION
Resolved an [issue](https://github.com/vinceliuice/Orchis-theme/issues/227) I opened the other day with some Sass guess-and-check. Looks like there were a few cases where the sass wasn't setting background colors explicitly and it was defaulting to something incorrect. Issue is resolved by explicitly setting background color to base color.

*Power off Dialog Dark Mode:*
![Screenshot from 2022-07-21 07-41-35](https://user-images.githubusercontent.com/26123763/180228297-11d029fe-4982-4431-b913-38c1fd26818d.png)

*Power off Dialog Light Mode:*
![Screenshot from 2022-07-21 07-41-54](https://user-images.githubusercontent.com/26123763/180228304-52e9cd79-b820-4666-b897-a37dcc4b5ec3.png)

