### PR TITLE
Remove border above bookmarks and equalize background color

### DIFF
--- a/src/firefox/chrome/Orchis/parts/headerbar.css
+++ b/src/firefox/chrome/Orchis/parts/headerbar.css
@@ -10,13 +10,13 @@
 
 /* Headerbar CSD colors */
 :root[tabsintitlebar] #nav-bar {
-	background: var(--gnome-headerbar-background) !important;
+  background-color: var(--toolbar-bgcolor);
+  background-image: var(--toolbar-bgimage);
 	border: none !important;
-	border-bottom: 1px solid var(--gnome-headerbar-border-color) !important;
+	border-bottom: 0 solid var(--gnome-headerbar-border-color) !important;
 	box-shadow: none !important;
 }
 :root[tabsintitlebar] #nav-bar:-moz-window-inactive {
-	background: var(--gnome-inactive-headerbar-background) !important;
-	border-bottom: 1px solid var(--gnome-inactive-headerbar-border-color) !important;
+	border-bottom: 0 solid var(--gnome-inactive-headerbar-border-color) !important;
 	box-shadow: none !important;
 }


### PR DESCRIPTION
I noticed a border above the bookmarks and that the bookmarks bar had a different color than the toolbar above, so I equalized them.

Before active:
![Screenshot from 2022-11-18 14-06-37](https://user-images.githubusercontent.com/1464877/202716531-ee6c8ab6-bcb6-42a7-ae1f-decc9b9a511e.png)
Before inactive:
![Screenshot from 2022-11-18 14-23-14](https://user-images.githubusercontent.com/1464877/202716560-dd405e45-5ba7-401b-a950-09a1b1b9fbe0.png)

After active:
![Screenshot from 2022-11-18 14-26-29](https://user-images.githubusercontent.com/1464877/202716593-546b10b6-51ef-49fd-b00a-39efe05158c5.png)
After inactive:
![Screenshot from 2022-11-18 14-26-36](https://user-images.githubusercontent.com/1464877/202716633-0ea21aa5-1355-4dee-aeeb-9c97bbdccc25.png)
