### PR TITLE
Partially Fixed #333 - Firefox drop down menus with invisible text

### DIFF
--- a/src/firefox/chrome/Orchis/parts/popups.css
+++ b/src/firefox/chrome/Orchis/parts/popups.css
@@ -19,6 +19,7 @@ menupopup {
 .menupopup-arrowscrollbox {
 	border: 0 !important;
 	background: var(--gnome-menu-background) !important;
+	color: var(--gnome-button-color) !important;
 }
 
 menupopup menupopup {


### PR DESCRIPTION
Fixed the problem with drop down menus in the firefox  dark themes

Before:

![image](https://user-images.githubusercontent.com/77760042/235816822-5543f4fe-4775-46b2-be19-0f600c5ed506.png)

After:

![image](https://user-images.githubusercontent.com/77760042/235816795-1f4f0387-e359-4c5f-b373-6050c758f0a5.png)
