### PR TITLE
bugfix: limit lowest value for corner-radious at 0

### DIFF
--- a/src/_sass/_variables.scss
+++ b/src/_sass/_variables.scss
@@ -24,7 +24,7 @@ $large-icon-size: 32px;
 //
 
 $window-radius: $default_corner + $space-size;
-$corner-radius: if($compact == 'false', $default_corner, $default_corner - 2px);
+$corner-radius: if($compact == 'false', $default_corner, max(0, $default_corner - 2px));
 $material-radius: $default_corner / 2 + 4px;
 $menu-radius: $default_corner / 4 + $space-size + 2px;
 $popup-radius: $default_corner + $space-size + 2px;


### PR DESCRIPTION
When using the `--tweaks compact` together with `--round 0`, gtk will spam warnings about `-2px` not being a valid value for `border-radious`.

Not sure if we want to change `(Suggested: 2px < value < 16px)` to something like `(Suggested: value < 16px)` ?