### PR TITLE
fixed install script error

### DIFF
--- a/core.sh
+++ b/core.sh
@@ -16,7 +16,7 @@ fi
 
 SASSC_OPT="-M -t expanded"
 
-THEME_NAME=Orchis
+THEME_NAME=$2
 THEME_VARIANTS=('' '-Purple' '-Pink' '-Red' '-Orange' '-Yellow' '-Green' '-Teal' '-Grey')
 COLOR_VARIANTS=('' '-Light' '-Dark')
 SIZE_VARIANTS=('' '-Compact')


### PR DESCRIPTION
When installing with a different name using the command `./install.sh -n Name`, the installation script creates a `/gtk-2.0/gtkrc` file by default in the `Orchis-*/gtk-2.0/gtkrc` directory.

