### PR TITLE
cinnamon.css: fix calendar applet scaled text bug

### DIFF
--- a/src/_sass/cinnamon/_common.scss
+++ b/src/_sass/cinnamon/_common.scss
@@ -806,7 +806,6 @@ $submenu_item_radius: $popup-radius - $space-size;
 
 .calendar-day-base {
   text-align: center;
-  width: 28px;
   height: 28px;
   padding: 0;
   margin: 2px;
@@ -866,7 +865,6 @@ $submenu_item_radius: $popup-radius - $space-size;
 }
 
 .calendar-week-number {
-  width: 20px;
   height: 20px;
   margin: 6px 0;
   color: $track;


### PR DESCRIPTION
Cinnamon calendar applet: remove width limit to allow for larger font sizes or cinnamon text scaling.

Before:
![Screenshot from 2024-06-20 20-09-42](https://github.com/vinceliuice/Orchis-theme/assets/58893963/836732e9-3500-4019-811a-056b3aa3b0c7)
After: 
![Screenshot from 2024-06-20 20-27-48](https://github.com/vinceliuice/Orchis-theme/assets/58893963/a3404ae3-b9ec-4246-a478-e9832962d4e1)
