### PR TITLE
Cinnamon: Fix vertical panel look

### DIFF
--- a/src/_sass/cinnamon/_common.scss
+++ b/src/_sass/cinnamon/_common.scss
@@ -2107,6 +2107,7 @@ $submenu_item_radius: $popup-radius - $space-size;
     text-shadow: none;
     transition-duration: 100ms;
     border-radius: 0;
+    text-align: center;
 
     &.vertical {
       padding: $space-size 0;

--- a/src/_sass/cinnamon/_common.scss
+++ b/src/_sass/cinnamon/_common.scss
@@ -1778,10 +1778,18 @@ $submenu_item_radius: $popup-radius - $space-size;
     color: rgba(on($panel-solid, secondary), 0.6);
     border-radius: 0;
     spacing: $space-size;
-    border-bottom: 2px solid transparent;
 
     &.top, &.bottom {
+      border-bottom: 2px solid transparent;
       padding: 0 2px;
+    }
+
+    &.left {
+      border-left: 2px solid transparent;
+    }
+
+    &.right {
+      border-right: 2px solid transparent;
     }
 
     &:hover {


### PR DESCRIPTION
Fix applet text alignment and GWL border orientation because it doesn't look good on vertical panels:
![verticalpanel-before](https://github.com/user-attachments/assets/858178be-11d4-42e0-a90f-202018efae29) → ![verticalpanel-after](https://github.com/user-attachments/assets/f5f1900f-2932-4571-8190-f7d997180ee4)