### PR TITLE
[HELP WANTED] Fix for System Menu Styles for Gnome 48

### DIFF
--- a/core.sh
+++ b/core.sh
@@ -336,11 +336,16 @@ check_shell() {
   elif [[ "$shell" == "47" ]]; then
     GS_VERSION="47-0"
     echo "Install for gnome-shell version = 47.0"
+  elif [[ "$shell" == "48" ]]; then
+    GS_VERSION="48-0"
+    echo "Install for gnome-shell version = 48.0"
   elif [[ "$(command -v gnome-shell)" ]]; then
     gnome-shell --version
     GNOME_SHELL="true"
     SHELL_VERSION="$(gnome-shell --version | cut -d ' ' -f 3 | cut -d . -f -1)"
-    if [[ "${SHELL_VERSION:-}" -ge "47" ]]; then
+    if [[ "${SHELL_VERSION:-}" -ge "48" ]]; then
+      GS_VERSION="48-0"
+    elif [[ "${SHELL_VERSION:-}" -ge "47" ]]; then
       GS_VERSION="47-0"
     elif [[ "${SHELL_VERSION:-}" -ge "46" ]]; then
       GS_VERSION="46-0"
@@ -355,7 +360,7 @@ check_shell() {
     fi
   else
     echo "'gnome-shell' not found, using styles for last gnome-shell version available."
-    GS_VERSION="47-0"
+    GS_VERSION="48-0"
     GNOME_SHELL="false"
   fi
 }
@@ -489,7 +494,7 @@ theme_tweaks() {
     activities_style
   fi
 
-  if [[ "$GNOME_SHELL" = "true" && "$GS_VERSION" = "47-0" ]] ; then
+  if [[ "$GNOME_SHELL" = "true" && ("$GS_VERSION" = "47-0" || "$GS_VERSION" = "48-0") ]] ; then
     gnome_version
   fi
 

--- a/src/_sass/gnome-shell/_widgets-48-0.scss
+++ b/src/_sass/gnome-shell/_widgets-48-0.scss
@@ -1,0 +1,53 @@
+//
+// Shell widgets stylesheets are placed in separate .scss files
+// in 'widgets' and imported into the main stylesheet in this file.
+// To create or update a widget for the shell modify the list below.
+//
+
+/* WIDGETS */
+
+// Primary widgets
+@import 'widgets/base';
+@import 'widgets/entries';
+@import 'widgets/buttons';
+@import 'widgets/check-box-47';
+@import 'widgets/switches-47';
+@import 'widgets/slider-47';
+@import 'widgets/scrollbars';
+// Popovers
+@import 'widgets/popovers-46';
+@import 'widgets/calendar-44';
+@import 'widgets/message-list-48';
+@import 'widgets/ibus-popup';
+@import 'widgets/quick-settings-48';
+// Notifications
+@import 'widgets/notifications-47';
+@import 'widgets/hotplug';
+// Dialogs
+@import 'widgets/dialogs-47';
+@import 'widgets/network-dialog';
+// OSDs
+@import 'widgets/osd-42';
+@import 'widgets/switcher-popup';
+@import 'widgets/workspace-switcher';
+// Panel
+@import 'widgets/panel';
+@import 'widgets/corner-ripple';
+// Overview
+@import 'widgets/overview';
+@import 'widgets/window-picker';
+@import 'widgets/search-entry';
+@import 'widgets/search-results-46';
+@import 'widgets/dash-46';
+@import 'widgets/app-grid-46';
+@import 'widgets/workspace-thumbnails';
+// A11y / misc
+@import 'widgets/a11y';
+@import 'widgets/misc';
+@import 'widgets/tiled-previews';
+@import 'widgets/keyboard';
+@import 'widgets/looking-glass';
+@import 'widgets/screenshot';
+// Lock / login screens
+@import 'widgets/login-dialog';
+@import 'widgets/screen-shield';

--- a/src/_sass/gnome-shell/widgets/_message-list-48.scss
+++ b/src/_sass/gnome-shell/widgets/_message-list-48.scss
@@ -1,0 +1,213 @@
+/* Message List */
+// a.k.a. notifications in the menu
+
+// main list
+.message-list {
+  width: 29em;
+  color: $text-secondary;
+  border: solid transparent;
+
+  // padding and margins to account for scrollbar
+  &:ltr { margin-left: 0; margin-right: 0; padding-right: 0; border-right-width: 0; }
+  &:rtl { margin-right: 0; margin-left: 0; padding-left: 0; border-left-width: 0; }
+
+  .message-list-placeholder {
+    @extend %title_2;
+    color: $text-secondary-disabled;
+
+    // icon size and color
+    > StIcon {
+      icon-size: 96px; // 48px
+      margin-bottom: $margin-size * 3;
+      -st-icon-style: symbolic;
+    }
+  }
+}
+
+.message-list-sections {
+  spacing: $space-size;
+
+  // to account for scrollbar
+  &:ltr { margin-right: $margin-size; padding-left: $space-size; }
+  &:rtl { margin-left: $margin-size; padding-right: $space-size; }
+}
+
+.message-list-section,
+.message-list-section-list {
+  spacing: $space-size;
+}
+
+// do-not-disturb + clear button
+.message-list-controls {
+  margin: ($margin-size * 2) ($margin-size * 4) 0;
+  // NOTE: remove the padding if notification_bubble could remove margin for drop shadow
+  padding: $margin-size;
+  spacing: $space-size * 2;
+  @extend %heading;
+
+  .dnd-button {
+    // We need this because the focus outline isn't inset like for the buttons
+    // so the dnd button would grow when it gets focus if we didn't change only
+    // its color when focusing.
+    border-width: 2px;
+    border-color: transparent;
+    border-radius: 32px;
+    border-style: solid;
+
+    &:focus {
+      border-color: transparentize($primary, 0.4);
+    }
+  }
+}
+
+// message bubbles
+.message {
+  border-radius: $material-radius;
+  padding: $space-size;
+  margin: 0;
+  // border-width: 0; // can not set this ?
+
+  .popup-menu & {
+    @extend .events-button;
+    box-shadow: none;
+    padding: $space-size;
+    margin: $margin-size;
+    color: $text-secondary;
+  }
+
+  // subtract side padding to accommodate the close button's border
+  &:ltr { padding-right: $space-size; }
+  &:rtl { padding-left: $space-size; }
+
+  // message header
+  .message-header {
+    padding: 0 $space-size;
+    spacing: $space-size;
+    color: $text-disabled;
+
+    &:ltr { padding-right: 0; }
+    &:rtl { padding-left: 0; }
+
+    // header source icon
+    .message-source-icon {
+      icon-size: $scalable-icon-size; // 16px
+      -st-icon-style: symbolic;
+    }
+
+    // box that contains the source icon, source name and timestamp of the message
+    .message-header-content {
+      spacing: $space-size;
+      min-height: to_em(24px);
+      padding-bottom: $space-size;
+
+      // header source title
+      .message-source-title {
+        font-weight: bold;
+      }
+
+      // Time label
+      .event-time {
+        @extend %caption;
+        color: $text-disabled;
+        // Add bottom padding to align the app name with the time horizontally
+        padding-bottom: to_em(1px);
+
+        &:ltr { text-align: right; }
+        &:rtl { text-align: left; }
+      }
+    }
+
+    // buttons in the message header
+    .message-expand-button,
+    .message-close-button {
+      @extend .icon-button;
+      color: $text;
+      background-color: $fill;
+      padding: $margin-size;
+
+      &:hover { background-color: $divider; }
+      &:active,
+      &:active:hover { background-color: $track; }
+      &:insensitive { background-color: transparent; }
+    }
+
+    .message-expand-button {
+      padding: $margin-size;
+
+      &:ltr { margin-right: $space-size; }
+      &:rtl { margin-left: $space-size; }
+    }
+  }
+
+  // container for message contents
+  .message-box {
+    padding: $space-size;
+    margin: $space-size;
+    margin-top: 0;
+    spacing: $space-size;
+
+    // icon of the message
+    .message-icon {
+      &:ltr { margin-right: $space-size; }
+      &:rtl { margin-left: $space-size; }
+
+      // icon size and color
+      icon-size: $base-icon-size * 3; // 48px
+      -st-icon-style: symbolic;
+
+      &.message-themed-icon {
+        border-radius: $circular-radius; // is circular
+        background-color: $divider;
+        icon-size: $base-icon-size;
+        min-width: $base-icon-size * 3;
+        min-height: $base-icon-size * 3;
+      }
+    }
+
+    // If the header isn't displayed we need more top margin
+    &:first-child {
+      margin-top: $space-size * 2;
+    }
+
+    // text of the message
+    .message-content {
+      spacing: $margin-size;
+
+      // message title
+      .message-title {
+        font-weight: bold;
+      }
+    }
+  }
+}
+
+// URLs in messages
+.url-highlighter {
+  link-color: $link;
+}
+
+/* Media Controls */
+.message-media-control {
+  margin: (16px - $space-size * 2) $space-size / 2 !important;
+  padding: 0 $space-size * 2 !important;
+  border-radius: $circular-radius;
+  color: $text-secondary;
+  border: none;
+
+  &:hover, &:focus { color: $text; background-color: $secondary-fill; }
+  &:active { color: $text; background-color: $track; }
+  &:insensitive { color: $text-secondary-disabled; }
+
+  & StIcon { icon-size: $base-icon-size; }
+}
+
+.media-message {
+  // album-art
+  .message-icon {
+    border-radius: $corner-radius / 2 !important;
+
+    &.message-themed-icon {
+      icon-size: $large-icon-size !important; // 32px
+    }
+  }
+}

--- a/src/_sass/gnome-shell/widgets/_quick-settings-48.scss
+++ b/src/_sass/gnome-shell/widgets/_quick-settings-48.scss
@@ -131,14 +131,9 @@ $toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
   }
 
   .quick-toggle-separator {
-    width: 1px;
-    // background-color: ?
-  }
-
-  &:checked {
-    .quick-toggle-separator {
-      // background-color: ?
-    }
+    width: 0px;
+    opacity: 0;
+    visibility: hidden;
   }
 }
 

--- a/src/_sass/gnome-shell/widgets/_quick-settings-48.scss
+++ b/src/_sass/gnome-shell/widgets/_quick-settings-48.scss
@@ -89,7 +89,7 @@ $toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
   }
 
   .quick-toggle-menu-button {
-    background-color: $secondary-fill !important;
+    background-color: rgba($text, 0.06) !important;
     padding: $space-size $space-size * 1.75;
     border: none !important;
 
@@ -99,16 +99,16 @@ $toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
     }
 
     &:hover {
-      background-color: $divider !important;
+      background-color: rgba($text, 0.12) !important;
     }
 
     &:active {
-      background-color: $track !important;
+      background-color: rgba($text, 0.24) !important;
     }
 
     &:checked {
       background-color: $primary !important;
-      color: on($primary);
+      color: on($primary) !important;
 
       &:focus {
         // background-color: ?
@@ -117,12 +117,12 @@ $toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
 
       &:hover {
         background-color: mix($text, $primary, 10%) !important;
-        color: on($primary);
+        color: on($primary) !important;
       }
 
       &:active {
         background-color: mix($text, $primary, 20%) !important;
-        color: on($primary);
+        color: on($primary) !important;
       }
     }
 

--- a/src/_sass/gnome-shell/widgets/_quick-settings-48.scss
+++ b/src/_sass/gnome-shell/widgets/_quick-settings-48.scss
@@ -1,0 +1,334 @@
+
+$toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
+
+.quick-settings {
+  padding: $space-size * 3 !important;
+  border-radius: 8px + $space-size * 5 !important;
+  margin-top: $space-size / 2 !important;
+  border: none;
+
+  .icon-button, .button {
+    padding: $space-size * 2;
+
+    > StIcon {
+      icon-size: $base-icon-size;
+    }
+  }
+}
+
+.quick-settings-grid {
+  spacing-rows: $space-size * 2;
+  spacing-columns: $space-size * 2;
+}
+
+.quick-toggle, .quick-menu-toggle {
+  border-radius: $circular-radius;
+  min-width: if($compact == 'false', 12em, 10.5em);
+  max-width: if($compact == 'false', 12em, 10.5em);
+  min-height: $toggle-height;
+  border: none;
+}
+
+.quick-toggle {
+  background-color: rgba($text, 0.06) !important;
+
+  &:hover {
+    background-color: rgba($text, 0.12) !important;
+  }
+
+  &:active {
+    background-color: rgba($text, 0.24) !important;
+  }
+
+  &:checked {
+    background-color: $primary !important;
+    color: on($primary) !important;
+
+    &:hover {
+      background-color: mix($text, $primary, 10%) !important;
+      color: on($primary) !important;
+    }
+
+    &:active {
+      background-color: mix($text, $primary, 20%) !important;
+      color: on($primary) !important;
+    }
+  }
+
+  & > StBoxLayout { spacing: $space-size; }
+
+  /* Move padding into the box; this is to allow menu arrows
+     to extend to the border */
+  &.button { padding: 0; }
+  & > StBoxLayout { padding: 0 $space-size * 2; }
+  &:ltr > StBoxLayout { padding-left: $space-size * 2.5; }
+  &:rtl > StBoxLayout { padding-right: $space-size * 2.5; }
+
+  .quick-toggle-title { font-weight: bold; }
+
+  & StBoxLayout > .quick-toggle-subtitle {
+    font-weight: normal;
+    font-size: 12px;
+  }
+
+  .quick-toggle-icon { icon-size: $base-icon-size; }
+}
+
+.quick-menu-toggle {
+  .quick-toggle {
+    min-width: auto;
+    max-width: auto;
+
+    &:ltr { border-radius: $circular-radius 0 0 $circular-radius; }
+    &:ltr > StBoxLayout { padding-right: 0; }
+    &:rtl { border-radius: 0 $circular-radius $circular-radius 0; }
+    &:rtr > StBoxLayout { padding-left: 0; }
+
+    &:ltr:last-child { border-radius: $circular-radius; }
+    &:rtl:last-child { border-radius: $circular-radius; }
+  }
+
+  .quick-toggle-arrow {
+    background-color: $secondary-fill !important;
+    padding: $space-size $space-size * 1.75;
+    border: none !important;
+
+    &:hover {
+      background-color: $divider !important;
+    }
+
+    &:active {
+      background-color: $track !important;
+    }
+
+    &:checked {
+      background-color: $primary !important;
+      color: on($primary);
+
+      &:hover {
+        background-color: mix($text, $primary, 10%) !important;
+        color: on($primary);
+      }
+
+      &:active {
+        background-color: mix($text, $primary, 20%) !important;
+        color: on($primary);
+      }
+    }
+
+    &:ltr { border-radius: 0 $circular-radius $circular-radius 0; }
+    &:rtl { border-radius: $circular-radius 0 0 $circular-radius; }
+  }
+}
+
+.quick-slider {
+  > StBoxLayout { spacing: $space-size; }
+
+  .icon-button {
+    padding: $space-size * 1.5;
+  }
+
+  .slider-bin {
+    &:focus { @include button(focus); }
+    min-height: $base-icon-size; // slider size
+    padding: $space-size;
+    border-radius: $circular-radius;
+  }
+
+  .quick-toggle-icon {
+    icon-size: $base-icon-size;
+  }
+}
+
+.quick-toggle-menu {
+  border-radius: $space-size * 5 !important;
+  padding: $space-size * 2;
+  margin: $space-size * 2 $space-size * 3.5 0;
+
+  @if $submenu_style == 'true' {
+    background-color: $surface !important;
+    color: $text-secondary !important;
+  } @else {
+    background-color: white !important;
+    color: rgba(black, 0.65) !important;
+  }
+
+  &:insensitive {
+    // override insensitive style on submenu
+    @if $submenu_style == 'true' {
+      background-color: $surface !important;
+      color: $text-secondary !important;
+    } @else {
+      background-color: white !important;
+      color: rgba(black, 0.65) !important;
+    }
+  }
+
+  .popup-menu-item {
+    padding: $space-size + 2px !important;
+    border-radius: $circular-radius !important;
+
+    @if $submenu_style == 'true' {
+      color: $text-secondary !important;
+
+      &:focus, &:hover, &.selected {
+        color: $text !important;
+        background-color: $secondary-fill !important;
+      }
+
+      &:active {
+        color: $text !important;
+        background-color: $divider !important;
+      }
+
+      &:insensitive {
+        color: $text-secondary-disabled !important;
+      }
+    } @else {
+      color: rgba(black, 0.65) !important;
+
+      StLabel { // FIXME: How to set color of network menu item on right
+        color: rgba(black, 0.65);
+      }
+
+      &:focus, &:hover, &.selected {
+        color: rgba(black, 0.75) !important;
+        background-color: rgba(black, 0.1) !important;
+      }
+
+      &:active {
+        color: rgba(black, 0.75) !important;
+        background-color: rgba(black, 0.2) !important;
+      }
+
+      &:insensitive {
+        color: rgba(black, 0.25) !important;
+      }
+    }
+
+    > StIcon {
+      -st-icon-style: symbolic;
+      icon-size: $scalable_icon_size;
+    }
+
+    & > :first-child {
+      &:ltr {
+        padding-left: $space-size  + $margin-size !important;
+      }
+
+      &:rtl {
+        padding-right: $space-size + $margin-size !important;
+      }
+    }
+
+    .popup-separator-menu-item-separator {
+      margin: $space-size $space-size * 3 $space-size 0 !important;
+      padding: 0 !important;
+
+      @if $submenu_style == 'true' {
+        background-color: $border !important;
+      } @else {
+        background-color: rgba(black, 0.1) !important;
+      }
+    }
+  }
+
+  & .header {
+    spacing-rows: 0.5 * $space-size;
+    spacing-columns: $space-size * 2;
+    padding-bottom: 2 * $space-size;
+
+    & .icon {
+      icon-size: 24px; // a non-standard symbolic size but ok
+      border-radius: $circular-radius;
+      padding: 1.5 * $space-size;
+      background-color: rgba(black, 0.08) !important;
+
+      &.active {
+        background-color: $primary !important;
+        color: on($primary) !important;
+      }
+    }
+
+    & .title {
+      @extend %title_3;
+    }
+
+    & .subtitle {
+      @extend %caption_heading;
+    }
+  }
+}
+
+.quick-settings-system-item {
+  & > StBoxLayout { spacing: 2 * $space-size; }
+
+  .icon-button {
+    background-color: rgba($text, 0.06);
+
+    &:hover { background-color: rgba($text, 0.12); }
+    &:active { background-color: rgba($text, 0.24); }
+
+    > StIcon { -st-icon-style: symbolic; }
+  }
+
+  & .power-item {
+    min-height: 0;
+    min-width: 0;
+
+    &:insensitive {
+      @include button(normal);
+      background-color: transparent;
+    }
+  }
+}
+
+.nm-network-item {
+  .wireless-secure-icon { icon-size: $base-icon-size / 2; }
+}
+
+.bt-device-item {
+  .popup-menu-icon { -st-icon-style: symbolic; }
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  @extend %title_4;
+  text-align: center;
+
+  padding: 2em 4em;
+}
+
+.device-subtitle { color: $text-disabled; }
+
+.keyboard-brightness-level {
+  spacing: $space-size;
+  background-color: $surface !important;
+  color: $text-secondary !important;
+
+  .button:checked { @extend %default_button; }
+}
+
+// background apps
+
+.background-apps-quick-toggle {
+  min-height: $toggle-height;
+  background-color: transparent;
+
+  & StIcon { icon-size: $base-icon-size !important; }
+}
+
+.background-app-item {
+  & .title { @extend %heading; }
+  & .subtitle { @extend %caption; }
+  & .popup-menu-icon {
+    icon-size: $large-icon-size !important;
+    -st-icon-style: regular !important;
+  }
+
+  & .close-button {
+    @extend .icon-button;
+    padding: $space-size;
+  }
+
+  &.popup-inactive-menu-item { color: $text; }
+}

--- a/src/_sass/gnome-shell/widgets/_quick-settings-48.scss
+++ b/src/_sass/gnome-shell/widgets/_quick-settings-48.scss
@@ -21,7 +21,7 @@ $toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
   spacing-columns: $space-size * 2;
 }
 
-.quick-toggle, .quick-menu-toggle {
+.quick-toggle, .quick-toggle-has-menu {
   border-radius: $circular-radius;
   min-width: if($compact == 'false', 12em, 10.5em);
   max-width: if($compact == 'false', 12em, 10.5em);
@@ -74,7 +74,7 @@ $toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
   .quick-toggle-icon { icon-size: $base-icon-size; }
 }
 
-.quick-menu-toggle {
+.quick-toggle-has-menu {
   .quick-toggle {
     min-width: auto;
     max-width: auto;
@@ -88,10 +88,15 @@ $toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
     &:rtl:last-child { border-radius: $circular-radius; }
   }
 
-  .quick-toggle-arrow {
+  .quick-toggle-menu-button {
     background-color: $secondary-fill !important;
     padding: $space-size $space-size * 1.75;
     border: none !important;
+
+    &:focus {
+      // background-color: ?
+      // color: ?
+    }
 
     &:hover {
       background-color: $divider !important;
@@ -104,6 +109,11 @@ $toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
     &:checked {
       background-color: $primary !important;
       color: on($primary);
+
+      &:focus {
+        // background-color: ?
+        // color: ?
+      }
 
       &:hover {
         background-color: mix($text, $primary, 10%) !important;
@@ -118,6 +128,17 @@ $toggle-height: $space-size * 4 + $margin-size + $base-icon-size;
 
     &:ltr { border-radius: 0 $circular-radius $circular-radius 0; }
     &:rtl { border-radius: $circular-radius 0 0 $circular-radius; }
+  }
+
+  .quick-toggle-separator {
+    width: 1px;
+    // background-color: ?
+  }
+
+  &:checked {
+    .quick-toggle-separator {
+      // background-color: ?
+    }
   }
 }
 

--- a/src/gnome-shell/shell-48-0/gnome-shell-Compact.css
+++ b/src/gnome-shell/shell-48-0/gnome-shell-Compact.css
@@ -1,0 +1,5085 @@
+/* This stylesheet is generated, DO NOT EDIT */
+stage {
+  font-size: 9.75pt;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.search-statustext {
+  font-size: 45px;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.modal-dialog .modal-dialog-linked-button, .hotplug-notification-item {
+  border: none;
+  margin-bottom: 4px;
+  color: rgba(0, 0, 0, 0.6);
+  background-color: rgba(0, 0, 0, 0.04);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+  font-size: 9.75pt;
+  font-weight: 500;
+}
+
+.modal-dialog .modal-dialog-linked-button:hover, .hotplug-notification-item:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.modal-dialog .modal-dialog-linked-button:active, .hotplug-notification-item:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.24);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.modal-dialog .modal-dialog-linked-button:insensitive, .hotplug-notification-item:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: rgba(0, 0, 0, 0.04);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.modal-dialog .modal-dialog-linked-button:focus, .hotplug-notification-item:focus {
+  color: #1A73E8;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.modal-dialog .modal-dialog-linked-button:focus:active, .hotplug-notification-item:focus:active {
+  color: white;
+}
+
+.modal-dialog .modal-dialog-linked-button:first-child, .hotplug-notification-item:first-child {
+  margin-left: 4px !important;
+  margin-right: 0 !important;
+  border-radius: 9999px 0 0 9999px;
+}
+
+.modal-dialog .modal-dialog-linked-button:last-child, .hotplug-notification-item:last-child {
+  margin-left: 0 !important;
+  margin-right: 4px !important;
+  border-right-width: 0;
+  border-radius: 0 9999px 9999px 0;
+}
+
+.modal-dialog .modal-dialog-linked-button:first-child:last-child, .hotplug-notification-item:first-child:last-child {
+  margin: 0 4px 4px 4px !important;
+  border-right-width: 0;
+  border-radius: 9999px;
+}
+
+.screenshot-ui-show-pointer-button, .screenshot-ui-type-button {
+  border: none;
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:insensitive, .screenshot-ui-type-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: #242424;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:focus, .screenshot-ui-type-button:focus {
+  color: #1A73E8;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.screenshot-ui-show-pointer-button:focus:active, .screenshot-ui-type-button:focus:active {
+  color: white;
+}
+
+.screenshot-ui-show-pointer-button:hover, .screenshot-ui-type-button:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:active, .screenshot-ui-type-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.24);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:outlined, .screenshot-ui-type-button:outlined, .screenshot-ui-show-pointer-button:checked, .screenshot-ui-type-button:checked {
+  color: white;
+  background-color: #1A73E8;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.workspace-switcher-container, .switcher-list, .resize-popup, .osd-monitor-label, .osd-window {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  border: none;
+  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.32);
+  padding: 8px;
+}
+
+/* General Typography */
+.message-list .message-list-placeholder {
+  font-weight: 800;
+  font-size: 15pt;
+}
+
+.quick-toggle-menu .header .title {
+  font-weight: 700;
+  font-size: 15pt;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  font-weight: 700;
+  font-size: 13pt;
+}
+
+.background-app-item .title, .message-list-controls {
+  font-weight: 700;
+  font-size: 11pt;
+}
+
+.quick-toggle-menu .header .subtitle, .app-menu .popup-inactive-menu-item:first-child > StLabel {
+  font-weight: 700;
+  font-size: 9pt;
+}
+
+.background-app-item .subtitle, .message .message-header .message-header-content .event-time {
+  font-weight: 400;
+  font-size: 9pt;
+}
+
+/* WIDGETS */
+.shell-link {
+  border-radius: 10px;
+  color: #1A73E8;
+  background-color: transparent;
+}
+
+.shell-link:hover {
+  color: #1A73E8;
+  background-color: rgba(26, 115, 232, 0.15);
+}
+
+.shell-link:active {
+  color: #1A73E8;
+  background-color: rgba(26, 115, 232, 0.3);
+}
+
+.lowres-icon {
+  icon-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.icon-dropshadow {
+  icon-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+}
+
+/* Entries */
+StEntry {
+  min-height: 32px;
+  padding: 0 8px;
+  border-radius: 9999px;
+  border-width: 0;
+  selection-background-color: rgba(26, 115, 232, 0.35) !important;
+  selected-color: #1A73E8 !important;
+  font-size: 11.25pt;
+  font-weight: 400;
+  caret-color: rgba(0, 0, 0, 0.6);
+  color: rgba(0, 0, 0, 0.6);
+  background-color: #FFFFFF;
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+StEntry:hover {
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.12) !important;
+}
+
+StEntry:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #1A73E8 !important;
+}
+
+StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+StEntry StIcon.capslock-warning {
+  icon-size: 16px;
+  warning-color: #FFD600;
+  padding: 0 4px;
+}
+
+StEntry StIcon.peek-password {
+  icon-size: 16px;
+  padding: 0 4px;
+}
+
+StEntry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+/* Buttons */
+.icon-button.flat, .background-app-item .flat.close-button, .message .message-header .flat.message-expand-button,
+.message .message-header .flat.message-close-button, .button.flat {
+  color: rgba(0, 0, 0, 0.6);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button.flat:focus, .background-app-item .flat.close-button:focus, .message .message-header .flat.message-expand-button:focus,
+.message .message-header .flat.message-close-button:focus, .button.flat:focus {
+  color: rgba(0, 0, 0, 0.87);
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.icon-button.flat:hover, .background-app-item .flat.close-button:hover, .message .message-header .flat.message-expand-button:hover,
+.message .message-header .flat.message-close-button:hover, .button.flat:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button.flat:selected, .background-app-item .flat.close-button:selected, .message .message-header .flat.message-expand-button:selected,
+.message .message-header .flat.message-close-button:selected, .button.flat:selected, .icon-button.flat:active, .background-app-item .flat.close-button:active, .message .message-header .flat.message-expand-button:active,
+.message .message-header .flat.message-close-button:active, .button.flat:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button.flat:checked, .background-app-item .flat.close-button:checked, .message .message-header .flat.message-expand-button:checked,
+.message .message-header .flat.message-close-button:checked, .button.flat:checked {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button.flat:insensitive, .background-app-item .flat.close-button:insensitive, .message .message-header .flat.message-expand-button:insensitive,
+.message .message-header .flat.message-close-button:insensitive, .button.flat:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.keyboard-brightness-level .button:checked, .icon-button.default, .background-app-item .default.close-button, .message .message-header .default.message-expand-button,
+.message .message-header .default.message-close-button, .button.default {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: #1A73E8;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.keyboard-brightness-level .button:focus:checked, .icon-button.default:focus, .background-app-item .default.close-button:focus, .message .message-header .default.message-expand-button:focus,
+.message .message-header .default.message-close-button:focus, .button.default:focus {
+  color: #1A73E8;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.keyboard-brightness-level .button:focus:active:checked, .icon-button.default:focus:active, .background-app-item .default.close-button:focus:active, .message .message-header .default.message-expand-button:focus:active,
+.message .message-header .default.message-close-button:focus:active, .button.default:focus:active {
+  color: white;
+}
+
+.keyboard-brightness-level .button:hover:checked, .icon-button.default:hover, .background-app-item .default.close-button:hover, .message .message-header .default.message-expand-button:hover,
+.message .message-header .default.message-close-button:hover, .button.default:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.keyboard-brightness-level .button:insensitive:checked, .icon-button.default:insensitive, .background-app-item .default.close-button:insensitive, .message .message-header .default.message-expand-button:insensitive,
+.message .message-header .default.message-close-button:insensitive, .button.default:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: #1A73E8;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.keyboard-brightness-level .button:active:checked, .icon-button.default:active, .background-app-item .default.close-button:active, .message .message-header .default.message-expand-button:active,
+.message .message-header .default.message-close-button:active, .button.default:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.24);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button {
+  min-height: 24px;
+  padding: 4px 8px;
+  border: none;
+  border-radius: 10px;
+  text-align: center;
+  font-size: 9.75pt;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.6);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:checked {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.icon-button, .background-app-item .close-button, .message .message-header .message-expand-button,
+.message .message-header .message-close-button {
+  min-height: 16px;
+  min-width: 16px;
+  padding: 8px;
+  border-radius: 9999px;
+  border: none;
+  color: rgba(0, 0, 0, 0.6);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:hover, .background-app-item .close-button:hover, .message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:active, .background-app-item .close-button:active, .message .message-header .message-expand-button:active,
+.message .message-header .message-close-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:checked, .background-app-item .close-button:checked, .message .message-header .message-expand-button:checked,
+.message .message-header .message-close-button:checked {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:insensitive, .background-app-item .close-button:insensitive, .message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:focus, .background-app-item .close-button:focus, .message .message-header .message-expand-button:focus,
+.message .message-header .message-close-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.icon-button StIcon, .background-app-item .close-button StIcon, .message .message-header .message-expand-button StIcon,
+.message .message-header .message-close-button StIcon {
+  icon-size: 16px;
+  -st-icon-style: symbolic;
+}
+
+/* Check Boxes */
+.check-box StBoxLayout {
+  spacing: .8em;
+}
+
+.check-box StBin {
+  width: 24px;
+  height: 24px;
+  padding: 4px;
+  border-radius: 100px;
+  background-image: url("assets/checkbox-off.svg");
+}
+
+.check-box:focus StBin {
+  background-image: url("assets/checkbox-off.svg");
+}
+
+.check-box:hover StBin {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.check-box:active StBin {
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.check-box:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:focus:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:hover:checked StBin {
+  background-color: rgba(26, 115, 232, 0.15);
+}
+
+.check-box:active:checked StBin {
+  background-color: rgba(26, 115, 232, 0.3);
+}
+
+/* Switches */
+.toggle-switch {
+  width: 44px;
+  height: 26px;
+  background-size: contain;
+  background-image: url("assets/toggle-off.svg");
+}
+
+.toggle-switch:checked {
+  background-image: url("assets/toggle-on.svg");
+}
+
+/* Slider */
+.slider {
+  height: 20px;
+  -barlevel-height: 2px;
+  -barlevel-background-color: rgba(0, 0, 0, 0.26);
+  -barlevel-border-width: 0;
+  -barlevel-border-color: rgba(0, 0, 0, 0.12);
+  -barlevel-active-background-color: #1A73E8;
+  -barlevel-active-border-color: #166ad8;
+  -barlevel-overdrive-color: #E53935;
+  -barlevel-overdrive-border-color: #e32723;
+  -barlevel-overdrive-separator-width: 2px;
+  -slider-handle-radius: 6px;
+  -slider-handle-border-width: 0;
+  -slider-handle-border-color: rgba(0, 0, 0, 0.12);
+  color: #1A73E8;
+}
+
+.slider:hover {
+  color: #3181ea;
+}
+
+.slider:active {
+  color: #1567d3;
+}
+
+/* Scrollbars */
+StScrollView.vfade {
+  -st-vfade-offset: 32px;
+}
+
+StScrollView.hfade {
+  -st-hfade-offset: 32px;
+}
+
+StScrollBar {
+  padding: 0;
+  margin: 6px;
+}
+
+StScrollView StScrollBar {
+  min-width: 8px;
+  min-height: 8px;
+}
+
+StScrollBar StBin#trough {
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+StScrollBar StButton#vhandle, StScrollBar StButton#hhandle {
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.38);
+  border: 4px solid transparent;
+  transition: 500ms all ease;
+}
+
+StScrollBar StButton#vhandle:hover, StScrollBar StButton#hhandle:hover {
+  background-color: rgba(0, 0, 0, 0.6);
+}
+
+StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
+  background-color: rgba(0, 0, 0, 0.87);
+}
+
+#LookingGlassDialog StScrollBar StBin#trough, #overviewGroup StScrollBar StBin#trough {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#LookingGlassDialog StScrollBar StButton#vhandle, #overviewGroup StScrollBar StButton#vhandle, #LookingGlassDialog StScrollBar StButton#hhandle, #overviewGroup StScrollBar StButton#hhandle {
+  background-color: rgba(255, 255, 255, 0.5);
+}
+
+#LookingGlassDialog StScrollBar StButton#vhandle:hover, #overviewGroup StScrollBar StButton#vhandle:hover, #LookingGlassDialog StScrollBar StButton#hhandle:hover, #overviewGroup StScrollBar StButton#hhandle:hover {
+  background-color: rgba(255, 255, 255, 0.7);
+}
+
+#LookingGlassDialog StScrollBar StButton#vhandle:active, #overviewGroup StScrollBar StButton#vhandle:active, #LookingGlassDialog StScrollBar StButton#hhandle:active, #overviewGroup StScrollBar StButton#hhandle:active {
+  background-color: white;
+}
+
+.popup-menu .popup-sub-menu StScrollBar StBin#trough {
+  background-color: rgba(0, 0, 0, 0.15);
+}
+
+.popup-menu .popup-sub-menu StScrollBar StButton#vhandle, .popup-menu .popup-sub-menu StScrollBar StButton#hhandle {
+  background-color: rgba(0, 0, 0, 0.35);
+}
+
+.popup-menu .popup-sub-menu StScrollBar StButton#vhandle:hover, .popup-menu .popup-sub-menu StScrollBar StButton#hhandle:hover {
+  background-color: rgba(0, 0, 0, 0.45);
+}
+
+.popup-menu .popup-sub-menu StScrollBar StButton#vhandle:active, .popup-menu .popup-sub-menu StScrollBar StButton#hhandle:active {
+  background-color: rgba(0, 0, 0, 0.65);
+}
+
+/* Popovers/Menus */
+.popup-menu-boxpointer {
+  -arrow-rise: 4px;
+  background: none;
+}
+
+.popup-menu {
+  min-width: 10em;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.popup-menu .popup-menu-content {
+  padding: 4px;
+  margin: 0 3px 14px;
+  background-color: rgba(255, 255, 255, 0.97);
+  border-radius: 16px;
+  border: none;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+}
+
+.popup-menu .popup-menu-item {
+  spacing: 4px;
+  padding: 4px 8px;
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: transparent;
+  transition-duration: 100ms;
+  border-radius: 12px;
+  background-image: none;
+  border: none;
+}
+
+.popup-menu .popup-menu-item:checked {
+  font-weight: normal;
+  border-radius: 12px 12px 0 0;
+  border: none;
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.1) !important;
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-menu-item:checked:hover, .popup-menu .popup-menu-item:checked:focus, .popup-menu .popup-menu-item:checked.selected {
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  color: rgba(0, 0, 0, 0.85) !important;
+}
+
+.popup-menu .popup-menu-item:checked:active {
+  background-color: #dfdfdf !important;
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-menu-item:checked.selected:active {
+  background-color: rgba(0, 0, 0, 0.15) !important;
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-menu-item:checked:insensitive {
+  color: rgba(0, 0, 0, 0.35) !important;
+}
+
+.popup-menu .popup-menu-item:hover, .popup-menu .popup-menu-item:focus, .popup-menu .popup-menu-item.selected {
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  transition-duration: 0ms;
+}
+
+.popup-menu .popup-menu-item:active {
+  background-color: rgba(0, 0, 0, 0.26) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  transition-duration: 150ms;
+}
+
+.popup-menu .popup-menu-item.selected:active {
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-menu .popup-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.38) !important;
+}
+
+.popup-menu .popup-menu-item .toggle-switch:ltr {
+  margin-left: 2px;
+}
+
+.popup-menu .popup-menu-item .toggle-switch:rtl {
+  margin-right: 2px;
+}
+
+.popup-menu .popup-ornamented-menu-item:ltr {
+  padding-left: 4px;
+}
+
+.popup-menu .popup-ornamented-menu-item:rtl {
+  padding-right: 4px;
+}
+
+.popup-menu .popup-inactive-menu-item {
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-menu .popup-inactive-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.38) !important;
+}
+
+.popup-menu .popup-menu-arrow,
+.popup-menu .popup-menu-icon {
+  icon-size: 16px;
+}
+
+.popup-menu .popup-sub-menu {
+  margin: 0;
+  border-radius: 0 0 12px 12px;
+  border: none;
+  box-shadow: none;
+  background-image: none;
+  color: rgba(0, 0, 0, 0.75) !important;
+  background-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item {
+  margin: 0;
+  border-radius: 12px;
+  background-image: none;
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item:hover, .popup-menu .popup-sub-menu .popup-menu-item:focus, .popup-menu .popup-sub-menu .popup-menu-item.selected {
+  color: rgba(0, 0, 0, 0.85) !important;
+  background-color: rgba(0, 0, 0, 0.15) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item:active {
+  color: rgba(0, 0, 0, 0.85) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item.selected:active {
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.35) !important;
+}
+
+.popup-menu .popup-menu-ornament {
+  icon-size: 1.091em !important;
+  width: 1.091em;
+}
+
+.popup-menu .popup-separator-menu-item {
+  background: none;
+  border: none;
+}
+
+.popup-menu .popup-separator-menu-item .popup-separator-menu-item-separator {
+  height: 1px;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.popup-sub-menu .popup-menu .popup-separator-menu-item {
+  background-color: transparent;
+}
+
+.popup-sub-menu .popup-menu .popup-separator-menu-item:ltr {
+  margin-right: 2.5em;
+  margin-left: 1.5em;
+}
+
+.popup-sub-menu .popup-menu .popup-separator-menu-item:rtl {
+  margin-left: 2.5em;
+  margin-right: 1.5em;
+}
+
+.popup-sub-menu .popup-menu .popup-separator-menu-item .popup-separator-menu-item-separator {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.popup-menu.panel-menu {
+  margin-bottom: 1.75em;
+}
+
+.background-menu {
+  -boxpointer-gap: 0px;
+  -arrow-rise: 0px;
+}
+
+.app-menu {
+  max-width: 27.25em;
+}
+
+.app-menu .popup-inactive-menu-item:first-child > StLabel:ltr {
+  margin-right: 4px;
+}
+
+.app-menu .popup-inactive-menu-item:first-child > StLabel:rtl {
+  margin-left: 4px;
+}
+
+/* Date/Time Menu */
+#calendarArea {
+  padding: 4px 0 !important;
+}
+
+.calendar {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none;
+  box-shadow: none;
+  background: none;
+  text-shadow: none;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.datemenu-calendar-column {
+  spacing: 4px;
+  border: none;
+  padding: 0 !important;
+  margin: 0 !important;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.datemenu-calendar-column:hover, .datemenu-calendar-column:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.datemenu-calendar-column:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.datemenu-calendar-column:ltr {
+  margin-right: 4px !important;
+  margin-left: 10px !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+  border-left-width: 0;
+}
+
+.datemenu-calendar-column:rtl {
+  margin-left: 4px !important;
+  margin-right: 10px !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+  border-right-width: 0;
+}
+
+.datemenu-calendar-column .datemenu-displays-box {
+  spacing: 4px;
+}
+
+.datemenu-today-button {
+  min-height: 40px;
+  padding: 4px;
+  border-radius: 10px;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  background: none;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.datemenu-today-button .day-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+}
+
+.datemenu-today-button .date-label {
+  font-size: 18pt;
+  font-weight: 400;
+}
+
+.datemenu-today-button:hover, .datemenu-today-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.datemenu-today-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.calendar-month-label {
+  height: 16px;
+  margin: 2px;
+  padding: 6px 16px;
+  border-radius: 10px;
+  color: rgba(0, 0, 0, 0.6) !important;
+  background-color: transparent !important;
+  font-weight: bold;
+  text-align: center;
+  text-shadow: none;
+}
+
+.calendar-month-label:focus {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.08) !important;
+}
+
+.pager-button {
+  width: 24px !important;
+  height: 24px !important;
+  margin: 2px !important;
+  padding: 2px !important;
+  border-radius: 9999px;
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.pager-button:hover, .pager-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+  box-shadow: none !important;
+}
+
+.pager-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.calendar-change-month-back StIcon,
+.calendar-change-month-forward StIcon {
+  icon-size: 16px;
+}
+
+.calendar-change-month-back {
+  padding: 0 2px;
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-change-month-back:rtl {
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward {
+  padding: 0 2px;
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward:rtl {
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-day {
+  font-size: 9pt;
+  font-weight: 400;
+  text-align: center;
+  width: 2.5em !important;
+  height: 2.5em !important;
+  padding: 0 !important;
+  margin: 2px !important;
+  border-radius: 9999px;
+  color: rgba(0, 0, 0, 0.6) !important;
+  border: none !important;
+  font-feature-settings: "tnum";
+  text-shadow: none;
+  background-color: transparent !important;
+}
+
+.calendar-day:hover, .calendar-day:focus {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  box-shadow: none;
+}
+
+.calendar-day:active {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.26) !important;
+  border: none !important;
+}
+
+.calendar-day:selected {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.26) !important;
+  border: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.calendar-day.calendar-weekend {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.calendar-day-heading {
+  width: 24px !important;
+  height: 20px !important;
+  margin-top: 2px !important;
+  padding: 4px 0 0 !important;
+  border-radius: 9999px;
+  background-color: transparent !important;
+  color: rgba(0, 0, 0, 0.38) !important;
+  font-size: 9pt;
+  font-weight: 400;
+  font-weight: bold;
+  text-align: center;
+}
+
+.calendar-day {
+  border-width: 0;
+}
+
+.calendar-day-top {
+  border-top-width: 0;
+}
+
+.calendar-day-left {
+  border-left-width: 0;
+}
+
+.calendar-nonwork-day {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.calendar-today {
+  font-weight: bold !important;
+  color: white !important;
+  background-color: #1A73E8 !important;
+  border: none;
+}
+
+.calendar-today:hover, .calendar-today:focus {
+  background-color: #287ce9 !important;
+  color: white !important;
+}
+
+.calendar-today:active, .calendar-today:selected {
+  background-color: #1A73E8 !important;
+  color: white !important;
+}
+
+.calendar-today:active:hover, .calendar-today:active:focus, .calendar-today:selected:hover, .calendar-today:selected:focus {
+  background-color: #287ce9 !important;
+  color: white !important;
+}
+
+.calendar-day-with-events {
+  color: rgba(0, 0, 0, 0.38);
+  background-image: url("assets/calendar-today.svg");
+  background-size: contain;
+}
+
+.calendar-day-with-events.calendar-work-day {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: bold;
+}
+
+.calendar-other-month {
+  color: rgba(0, 0, 0, 0.26) !important;
+  font-weight: normal;
+}
+
+.calendar-other-month.calendar-weekend {
+  color: rgba(0, 0, 0, 0.26) !important;
+}
+
+.calendar-week-number {
+  margin: 6px !important;
+  padding: 0 5px !important;
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.04);
+  color: rgba(0, 0, 0, 0.38);
+  font-size: 8.25pt;
+  font-weight: bold;
+  text-align: center;
+  text-shadow: none;
+  font-feature-settings: "tnum";
+}
+
+.world-clocks-button,
+.weather-button,
+.events-button,
+.popup-menu .message {
+  padding: 4px 8px;
+  border-radius: 10px;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  color: rgba(0, 0, 0, 0.6);
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+.world-clocks-button:hover, .world-clocks-button:focus,
+.weather-button:hover,
+.weather-button:focus,
+.events-button:hover,
+.popup-menu .message:hover,
+.events-button:focus,
+.popup-menu .message:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.world-clocks-button:active,
+.weather-button:active,
+.events-button:active,
+.popup-menu .message:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.world-clocks-header,
+.weather-header,
+.message-list-section-title,
+.events-section-title,
+.events-title {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: bold;
+  margin-bottom: 2px;
+  text-shadow: none;
+}
+
+.weather-grid,
+.world-clocks-grid {
+  spacing-rows: 8px;
+  spacing-columns: 16px;
+}
+
+.world-clocks-header,
+.weather-header,
+.events-section-title {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: bold;
+  font-size: 0.9em;
+}
+
+.events-button .events-box, .popup-menu .message .events-box {
+  spacing: 6px;
+}
+
+.events-button .events-list, .popup-menu .message .events-list {
+  color: rgba(0, 0, 0, 0.6);
+  spacing: 12px;
+  text-shadow: none;
+}
+
+.events-button .event-time, .popup-menu .message .event-time {
+  color: rgba(0, 0, 0, 0.26);
+  font-feature-settings: "tnum";
+}
+
+.world-clocks-button .world-clocks-city {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: normal;
+  font-size: 0.9em;
+}
+
+.world-clocks-button .world-clocks-time {
+  color: rgba(0, 0, 0, 0.38);
+  font-feature-settings: "tnum";
+  font-weight: bold;
+  font-size: 0.9em;
+}
+
+.world-clocks-button .world-clocks-time:ltr {
+  text-align: right;
+}
+
+.world-clocks-button .world-clocks-time:rtl {
+  text-align: left;
+}
+
+.world-clocks-button .world-clocks-timezone {
+  color: rgba(0, 0, 0, 0.38);
+  font-feature-settings: "tnum";
+  font-size: 0.9em;
+}
+
+.weather-button .weather-box {
+  spacing: 12px;
+}
+
+.weather-button .weather-header-box {
+  spacing: 8px;
+}
+
+.weather-button .weather-header.location {
+  font-weight: normal;
+  color: rgba(0, 0, 0, 0.38);
+  font-size: 0.8em;
+}
+
+.weather-button .weather-forecast-icon {
+  icon-size: 24px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.weather-button .weather-forecast-time {
+  color: rgba(0, 0, 0, 0.38);
+  font-size: 0.7em;
+  font-feature-settings: "tnum";
+  font-weight: normal;
+  padding-top: 0.2em;
+  padding-bottom: 0.4em;
+}
+
+.weather-button .weather-forecast-temp {
+  font-weight: bold;
+  color: rgba(0, 0, 0, 0.52);
+  text-shadow: none;
+}
+
+/* Message List */
+.message-list {
+  width: 29em;
+  color: rgba(0, 0, 0, 0.6);
+  border: solid transparent;
+}
+
+.message-list:ltr {
+  margin-left: 0;
+  margin-right: 0;
+  padding-right: 0;
+  border-right-width: 0;
+}
+
+.message-list:rtl {
+  margin-right: 0;
+  margin-left: 0;
+  padding-left: 0;
+  border-left-width: 0;
+}
+
+.message-list .message-list-placeholder {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.message-list .message-list-placeholder > StIcon {
+  icon-size: 96px;
+  margin-bottom: 6px;
+  -st-icon-style: symbolic;
+}
+
+.message-list-sections {
+  spacing: 4px;
+}
+
+.message-list-sections:ltr {
+  margin-right: 2px;
+  padding-left: 4px;
+}
+
+.message-list-sections:rtl {
+  margin-left: 2px;
+  padding-right: 4px;
+}
+
+.message-list-section,
+.message-list-section-list {
+  spacing: 4px;
+}
+
+.message-list-controls {
+  margin: 4px 8px 0;
+  padding: 2px;
+  spacing: 8px;
+}
+
+.message-list-controls .dnd-button {
+  border-width: 2px;
+  border-color: transparent;
+  border-radius: 32px;
+  border-style: solid;
+}
+
+.message-list-controls .dnd-button:focus {
+  border-color: rgba(26, 115, 232, 0.6);
+}
+
+.message {
+  border-radius: 10px;
+  padding: 0;
+  margin: 0;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.32);
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(255, 255, 255, 0.96);
+}
+
+.message:hover, .message:focus, .message:active {
+  background-color: #FFFFFF;
+}
+
+.popup-menu .message {
+  border: 1px solid transparent;
+  border-left: none;
+  border-bottom: none;
+  padding: 0;
+  margin: 0;
+  box-shadow: none;
+  margin: 2px;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.message:ltr {
+  padding-right: -2px;
+}
+
+.message:rtl {
+  padding-left: -2px;
+}
+
+.message .message-header {
+  padding: 0 0.409em;
+  margin: 4px;
+  margin-bottom: 0;
+  spacing: 4px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.message .message-header .message-source-icon {
+  icon-size: 1.091em;
+  -st-icon-style: symbolic;
+}
+
+.message .message-header .message-header-content {
+  spacing: 4px;
+  min-height: 1.637em;
+  padding-bottom: 4px;
+}
+
+.message .message-header .message-header-content .message-source-title {
+  font-weight: bold;
+}
+
+.message .message-header .message-header-content .event-time {
+  color: rgba(0, 0, 0, 0.38);
+  padding-bottom: 0.068em;
+}
+
+.message .message-header .message-header-content .event-time:ltr {
+  text-align: right;
+}
+
+.message .message-header .message-header-content .event-time:rtl {
+  text-align: left;
+}
+
+.message .message-header .message-expand-button,
+.message .message-header .message-close-button {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.04);
+  padding: 2px;
+}
+
+.message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.message .message-header .message-expand-button:active, .message .message-header .message-expand-button:active:hover,
+.message .message-header .message-close-button:active,
+.message .message-header .message-close-button:active:hover {
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive {
+  background-color: transparent;
+}
+
+.message .message-header .message-expand-button {
+  padding: 2px;
+}
+
+.message .message-header .message-expand-button:ltr {
+  margin-right: 4px;
+}
+
+.message .message-header .message-expand-button:rtl {
+  margin-left: 4px;
+}
+
+.message .message-box {
+  padding: 4px;
+  margin: 4px;
+  margin-top: 0;
+  spacing: 4px;
+}
+
+.message .message-box .message-icon {
+  icon-size: 48px;
+  -st-icon-style: symbolic;
+}
+
+.message .message-box .message-icon:ltr {
+  margin-right: 4px;
+}
+
+.message .message-box .message-icon:rtl {
+  margin-left: 4px;
+}
+
+.message .message-box .message-icon.message-themed-icon {
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.12);
+  icon-size: 16px;
+  min-width: 48px;
+  min-height: 48px;
+}
+
+.message .message-box:first-child {
+  margin-top: 8px;
+}
+
+.message .message-box .message-content {
+  spacing: 2px;
+}
+
+.message .message-box .message-content .message-title {
+  font-weight: bold;
+}
+
+.url-highlighter {
+  link-color: #1A73E8;
+}
+
+/* Media Controls */
+.message-media-control {
+  margin: 8px 2px !important;
+  padding: 0 8px !important;
+  border-radius: 9999px;
+  color: rgba(0, 0, 0, 0.6);
+  border: none;
+}
+
+.message-media-control:hover, .message-media-control:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.message-media-control:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.message-media-control:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.message-media-control StIcon {
+  icon-size: 16px;
+}
+
+.media-message .message-icon {
+  border-radius: 5px !important;
+}
+
+.media-message .message-icon.message-themed-icon {
+  icon-size: 32px !important;
+}
+
+.candidate-popup-boxpointer {
+  -arrow-border-radius: 2px;
+  -arrow-background-color: transparent;
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 64px;
+  -arrow-rise: 12px;
+}
+
+.candidate-popup-content {
+  background-color: #FFFFFF;
+  border-radius: 9px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+  margin: 2px 10px 13px;
+  padding: 4px;
+  spacing: 4px;
+  border: none;
+}
+
+.candidate-index {
+  padding: 0 0.5em 0 0;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.candidate-box:selected .candidate-index {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.candidate-box {
+  padding: 0.3em 0.5em 0.3em 0.5em;
+  margin-right: 2px;
+  border-radius: 5px;
+}
+
+.candidate-box:hover {
+  background-color: rgba(0, 0, 0, 0.08);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.candidate-box:active {
+  background-color: rgba(0, 0, 0, 0.26);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.candidate-box:selected {
+  background-color: #1A73E8;
+  color: white;
+}
+
+.candidate-box:last-child {
+  margin-right: 0;
+}
+
+.candidate-page-button-box {
+  height: 2em;
+}
+
+.vertical .candidate-page-button-box {
+  padding-top: 0.5em;
+}
+
+.horizontal .candidate-page-button-box {
+  padding-left: 0.5em;
+}
+
+.candidate-page-button {
+  padding: 4px 8px;
+}
+
+.candidate-page-button-previous {
+  border-radius: 5px;
+  border-right-width: 0;
+}
+
+.candidate-page-button-next {
+  border-radius: 5px;
+  margin-left: 2px;
+}
+
+.candidate-page-button-icon {
+  icon-size: 1em;
+}
+
+.quick-settings {
+  padding: 12px !important;
+  border-radius: 28px !important;
+  margin-top: 2px !important;
+  border: none;
+}
+
+.quick-settings .icon-button, .quick-settings .background-app-item .close-button, .background-app-item .quick-settings .close-button, .quick-settings .message .message-header .message-expand-button, .message .message-header .quick-settings .message-expand-button,
+.quick-settings .message .message-header .message-close-button,
+.message .message-header .quick-settings .message-close-button, .quick-settings .button {
+  padding: 8px;
+}
+
+.quick-settings .icon-button > StIcon, .quick-settings .background-app-item .close-button > StIcon, .background-app-item .quick-settings .close-button > StIcon, .quick-settings .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings .message-expand-button > StIcon,
+.quick-settings .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings .message-close-button > StIcon, .quick-settings .button > StIcon {
+  icon-size: 16px;
+}
+
+.quick-settings-grid {
+  spacing-rows: 8px;
+  spacing-columns: 8px;
+}
+
+.quick-toggle, .quick-menu-toggle {
+  border-radius: 9999px;
+  min-width: 10.5em;
+  max-width: 10.5em;
+  min-height: 34px;
+  border: none;
+}
+
+.quick-toggle {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  /* Move padding into the box; this is to allow menu arrows
+     to extend to the border */
+}
+
+.quick-toggle:hover {
+  background-color: rgba(0, 0, 0, 0.12) !important;
+}
+
+.quick-toggle:active {
+  background-color: rgba(0, 0, 0, 0.24) !important;
+}
+
+.quick-toggle:checked {
+  background-color: #1A73E8 !important;
+  color: white !important;
+}
+
+.quick-toggle:checked:hover {
+  background-color: rgba(24, 106, 214, 0.987) !important;
+  color: white !important;
+}
+
+.quick-toggle:checked:active {
+  background-color: rgba(22, 96, 195, 0.974) !important;
+  color: white !important;
+}
+
+.quick-toggle > StBoxLayout {
+  spacing: 4px;
+}
+
+.quick-toggle.button {
+  padding: 0;
+}
+
+.quick-toggle > StBoxLayout {
+  padding: 0 8px;
+}
+
+.quick-toggle:ltr > StBoxLayout {
+  padding-left: 10px;
+}
+
+.quick-toggle:rtl > StBoxLayout {
+  padding-right: 10px;
+}
+
+.quick-toggle .quick-toggle-title {
+  font-weight: bold;
+}
+
+.quick-toggle StBoxLayout > .quick-toggle-subtitle {
+  font-weight: normal;
+  font-size: 12px;
+}
+
+.quick-toggle .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-menu-toggle .quick-toggle {
+  min-width: auto;
+  max-width: auto;
+}
+
+.quick-menu-toggle .quick-toggle:ltr {
+  border-radius: 9999px 0 0 9999px;
+}
+
+.quick-menu-toggle .quick-toggle:ltr > StBoxLayout {
+  padding-right: 0;
+}
+
+.quick-menu-toggle .quick-toggle:rtl {
+  border-radius: 0 9999px 9999px 0;
+}
+
+.quick-menu-toggle .quick-toggle:rtr > StBoxLayout {
+  padding-left: 0;
+}
+
+.quick-menu-toggle .quick-toggle:ltr:last-child {
+  border-radius: 9999px;
+}
+
+.quick-menu-toggle .quick-toggle:rtl:last-child {
+  border-radius: 9999px;
+}
+
+.quick-menu-toggle .quick-toggle-arrow {
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  padding: 4px 7px;
+  border: none !important;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:hover {
+  background-color: rgba(0, 0, 0, 0.12) !important;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:active {
+  background-color: rgba(0, 0, 0, 0.26) !important;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:checked {
+  background-color: #1A73E8 !important;
+  color: white;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:checked:hover {
+  background-color: rgba(24, 106, 214, 0.987) !important;
+  color: white;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:checked:active {
+  background-color: rgba(22, 96, 195, 0.974) !important;
+  color: white;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:ltr {
+  border-radius: 0 9999px 9999px 0;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:rtl {
+  border-radius: 9999px 0 0 9999px;
+}
+
+.quick-slider > StBoxLayout {
+  spacing: 4px;
+}
+
+.quick-slider .icon-button, .quick-slider .background-app-item .close-button, .background-app-item .quick-slider .close-button, .quick-slider .message .message-header .message-expand-button, .message .message-header .quick-slider .message-expand-button,
+.quick-slider .message .message-header .message-close-button,
+.message .message-header .quick-slider .message-close-button {
+  padding: 6px;
+}
+
+.quick-slider .slider-bin {
+  min-height: 16px;
+  padding: 4px;
+  border-radius: 9999px;
+}
+
+.quick-slider .slider-bin:focus {
+  color: #1A73E8;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.quick-slider .slider-bin:focus:active {
+  color: white;
+}
+
+.quick-slider .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-toggle-menu {
+  border-radius: 20px !important;
+  padding: 8px;
+  margin: 8px 14px 0;
+  background-color: white !important;
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+.quick-toggle-menu:insensitive {
+  background-color: white !important;
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+.quick-toggle-menu .popup-menu-item {
+  padding: 6px !important;
+  border-radius: 9999px !important;
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+.quick-toggle-menu .popup-menu-item StLabel {
+  color: rgba(0, 0, 0, 0.65);
+}
+
+.quick-toggle-menu .popup-menu-item:focus, .quick-toggle-menu .popup-menu-item:hover, .quick-toggle-menu .popup-menu-item.selected {
+  color: rgba(0, 0, 0, 0.75) !important;
+  background-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.quick-toggle-menu .popup-menu-item:active {
+  color: rgba(0, 0, 0, 0.75) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+
+.quick-toggle-menu .popup-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.25) !important;
+}
+
+.quick-toggle-menu .popup-menu-item > StIcon {
+  -st-icon-style: symbolic;
+  icon-size: 1.091em;
+}
+
+.quick-toggle-menu .popup-menu-item > :first-child:ltr {
+  padding-left: 6px !important;
+}
+
+.quick-toggle-menu .popup-menu-item > :first-child:rtl {
+  padding-right: 6px !important;
+}
+
+.quick-toggle-menu .popup-menu-item .popup-separator-menu-item-separator {
+  margin: 4px 12px 4px 0 !important;
+  padding: 0 !important;
+  background-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.quick-toggle-menu .header {
+  spacing-rows: 2px;
+  spacing-columns: 8px;
+  padding-bottom: 8px;
+}
+
+.quick-toggle-menu .header .icon {
+  icon-size: 24px;
+  border-radius: 9999px;
+  padding: 6px;
+  background-color: rgba(0, 0, 0, 0.08) !important;
+}
+
+.quick-toggle-menu .header .icon.active {
+  background-color: #1A73E8 !important;
+  color: white !important;
+}
+
+.quick-settings-system-item > StBoxLayout {
+  spacing: 8px;
+}
+
+.quick-settings-system-item .icon-button, .quick-settings-system-item .background-app-item .close-button, .background-app-item .quick-settings-system-item .close-button, .quick-settings-system-item .message .message-header .message-expand-button, .message .message-header .quick-settings-system-item .message-expand-button,
+.quick-settings-system-item .message .message-header .message-close-button,
+.message .message-header .quick-settings-system-item .message-close-button {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.quick-settings-system-item .icon-button:hover, .quick-settings-system-item .background-app-item .close-button:hover, .background-app-item .quick-settings-system-item .close-button:hover, .quick-settings-system-item .message .message-header .message-expand-button:hover, .message .message-header .quick-settings-system-item .message-expand-button:hover,
+.quick-settings-system-item .message .message-header .message-close-button:hover,
+.message .message-header .quick-settings-system-item .message-close-button:hover {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.quick-settings-system-item .icon-button:active, .quick-settings-system-item .background-app-item .close-button:active, .background-app-item .quick-settings-system-item .close-button:active, .quick-settings-system-item .message .message-header .message-expand-button:active, .message .message-header .quick-settings-system-item .message-expand-button:active,
+.quick-settings-system-item .message .message-header .message-close-button:active,
+.message .message-header .quick-settings-system-item .message-close-button:active {
+  background-color: rgba(0, 0, 0, 0.24);
+}
+
+.quick-settings-system-item .icon-button > StIcon, .quick-settings-system-item .background-app-item .close-button > StIcon, .background-app-item .quick-settings-system-item .close-button > StIcon, .quick-settings-system-item .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings-system-item .message-expand-button > StIcon,
+.quick-settings-system-item .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings-system-item .message-close-button > StIcon {
+  -st-icon-style: symbolic;
+}
+
+.quick-settings-system-item .power-item {
+  min-height: 0;
+  min-width: 0;
+}
+
+.quick-settings-system-item .power-item:insensitive {
+  color: rgba(0, 0, 0, 0.6);
+  background-color: rgba(0, 0, 0, 0.04);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+  background-color: transparent;
+}
+
+.nm-network-item .wireless-secure-icon {
+  icon-size: 8px;
+}
+
+.bt-device-item .popup-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  text-align: center;
+  padding: 2em 4em;
+}
+
+.device-subtitle {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.keyboard-brightness-level {
+  spacing: 4px;
+  background-color: #FFFFFF !important;
+  color: rgba(0, 0, 0, 0.6) !important;
+}
+
+.background-apps-quick-toggle {
+  min-height: 34px;
+  background-color: transparent;
+}
+
+.background-apps-quick-toggle StIcon {
+  icon-size: 16px !important;
+}
+
+.background-app-item .popup-menu-icon {
+  icon-size: 32px !important;
+  -st-icon-style: regular !important;
+}
+
+.background-app-item .close-button {
+  padding: 4px;
+}
+
+.background-app-item.popup-inactive-menu-item {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+/* Notifications & Message Tray */
+.notification-banner {
+  min-height: 64px;
+  width: 34em;
+  font-size: 1em;
+  margin: 4px;
+  border-radius: 16px;
+  border-left: none;
+  border-bottom: none;
+}
+
+.notification-buttons-bin {
+  background-color: transparent;
+  padding: 0;
+  spacing: 0;
+  margin: 0;
+}
+
+.notification-button {
+  min-height: 40px;
+  padding: 2px 16px;
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.6);
+  font-weight: 500;
+  border: none;
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.popup-menu .notification-button {
+  padding: 0 16px;
+}
+
+.notification-button:first-child:ltr {
+  border-radius: 0 0 0 16px;
+}
+
+.notification-button:last-child:ltr {
+  border-radius: 0 0 16px;
+  margin-right: 0 !important;
+}
+
+.notification-button:first-child:rtl {
+  border-radius: 0 0 16px;
+}
+
+.notification-button:last-child:rtl {
+  border-radius: 0 0 0 16px;
+  margin-left: 0 !important;
+}
+
+.notification-button:first-child:last-child {
+  border-radius: 0 0 16px 16px;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.notification-button:focus {
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.6);
+  box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.08);
+}
+
+.notification-button:hover {
+  background-color: rgba(0, 0, 0, 0.08);
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.notification-button:active, .notification-button:checked {
+  background-color: rgba(0, 0, 0, 0.26);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.notification-button:insensitive {
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.popup-menu .notification-button:first-child:ltr {
+  border-radius: 0 0 0 10px;
+}
+
+.popup-menu .notification-button:last-child:ltr {
+  border-radius: 0 0 10px;
+}
+
+.popup-menu .notification-button:first-child:rtl {
+  border-radius: 0 0 10px;
+}
+
+.popup-menu .notification-button:last-child:rtl {
+  border-radius: 0 0 0 10px;
+}
+
+.popup-menu .notification-button:first-child:last-child {
+  border-radius: 0 0 10px 10px;
+}
+
+.hotplug-notification-item {
+  padding: 2px 10px;
+}
+
+.hotplug-notification-item-icon {
+  icon-size: 24px;
+  padding: 0 4px;
+}
+
+/* Modal Dialogs */
+.headline {
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.modal-dialog {
+  border-radius: 24px;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  border: 0 none rgba(0, 0, 0, 0.15);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+}
+
+.modal-dialog .modal-dialog-content-box {
+  margin: 32px 40px;
+  spacing: 32px;
+  max-width: 28em;
+  background-color: #FFFFFF;
+}
+
+.modal-dialog .modal-dialog-linked-button {
+  min-height: 40px;
+  padding: 0 16px;
+}
+
+/* End Session Dialog */
+.end-session-dialog {
+  width: 30em;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child {
+  color: white !important;
+  background-color: #E53935;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:hover {
+  color: white !important;
+  background-color: #ea615e;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:active {
+  color: white !important;
+  background-color: #e2231e;
+}
+
+.end-session-dialog .end-session-dialog-battery-warning,
+.end-session-dialog .dialog-list-title {
+  color: #FFD600;
+}
+
+/* Message Dialog */
+.message-dialog-content {
+  spacing: 18px;
+}
+
+.message-dialog-content .message-dialog-title {
+  text-align: center;
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-title.lightweight {
+  font-size: 13pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-description {
+  text-align: center;
+}
+
+/* Dialog List */
+.dialog-list {
+  spacing: 18px;
+}
+
+.dialog-list .dialog-list-title {
+  text-align: center;
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-scrollview {
+  max-height: 200px;
+}
+
+.dialog-list .dialog-list-box {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-title {
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-description {
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+/* Run Dialog */
+.run-dialog .modal-dialog-content-box {
+  margin-top: 24px;
+  margin-bottom: 14px;
+}
+
+.run-dialog .run-dialog-entry {
+  width: 20em;
+}
+
+.run-dialog .run-dialog-description {
+  font-size: 11.25pt;
+  font-weight: 400;
+  text-align: center;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+/* Password or Authentication Dialog */
+.prompt-dialog {
+  width: 28em;
+}
+
+.prompt-dialog .modal-dialog-linked-button:first-child {
+  color: #E53935;
+}
+
+.prompt-dialog .modal-dialog-linked-button:first-child:active {
+  color: white !important;
+  background-color: #E53935;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child {
+  color: white !important;
+  background-color: #1A73E8;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:hover {
+  color: white !important;
+  background-color: #448dec;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:active {
+  color: white !important;
+  background-color: #1567d3;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:insensitive {
+  color: rgba(26, 115, 232, 0.5) !important;
+  background-color: rgba(26, 115, 232, 0.15);
+}
+
+.prompt-dialog .modal-dialog-content-box {
+  margin-bottom: 24px;
+  background-color: #FFFFFF;
+}
+
+.prompt-dialog-password-grid {
+  spacing-rows: 8px;
+  spacing-columns: 4px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry {
+  width: auto;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:ltr {
+  margin-left: 20px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:rtl {
+  margin-right: 20px;
+}
+
+.prompt-dialog-password-layout {
+  spacing: 8px;
+}
+
+.prompt-dialog-password-entry {
+  width: 20em;
+}
+
+.prompt-dialog-error-label,
+.prompt-dialog-info-label,
+.prompt-dialog-null-label {
+  text-align: center;
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.prompt-dialog-error-label {
+  color: #FFD600;
+}
+
+/* Polkit Dialog */
+.polkit-dialog-user-layout {
+  text-align: center;
+  spacing: 8px;
+  margin-bottom: 6px;
+}
+
+.polkit-dialog-user-layout .polkit-dialog-user-root-label {
+  color: #FFD600;
+}
+
+/* Audio selection dialog */
+.audio-device-selection-dialog .modal-dialog-content-box {
+  margin-bottom: 28px;
+}
+
+.audio-device-selection-dialog .audio-selection-box {
+  spacing: 20px;
+}
+
+.audio-selection-device {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 10px;
+}
+
+.audio-selection-device:active, .audio-selection-device:hover, .audio-selection-device:focus {
+  background-color: #1A73E8;
+}
+
+.audio-selection-device-box {
+  padding: 20px;
+  spacing: 20px;
+}
+
+.audio-selection-device-icon {
+  icon-size: 64px;
+}
+
+/* Welcome dialog */
+.welcome-dialog-image {
+  background-image: url("resource:///org/gnome/shell/theme/gnome-shell-start.svg");
+  background-size: contain;
+  /* Reasonable maximum dimensions */
+  height: 300px;
+  width: 300px;
+}
+
+/* Network Dialogs */
+.nm-dialog {
+  max-height: 34em;
+  min-height: 31em;
+  min-width: 32em;
+}
+
+.nm-dialog-content {
+  spacing: 20px;
+  padding: 24px;
+}
+
+.nm-dialog-airplane-box {
+  spacing: 12px;
+}
+
+.nm-dialog-airplane-headline {
+  font-weight: bold;
+  text-align: center;
+}
+
+.nm-dialog-airplane-text {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.nm-dialog-header {
+  font-weight: bold;
+}
+
+.nm-dialog-header-icon {
+  icon-size: 32px;
+}
+
+.nm-dialog-header-hbox {
+  spacing: 10px;
+}
+
+.nm-dialog-scroll-view {
+  border: none;
+  background-color: rgba(0, 0, 0, 0.08);
+  border-radius: 10px;
+  padding: 8px;
+  padding-right: 0;
+}
+
+.nm-dialog-item {
+  font-size: 1em;
+  border-bottom: none;
+  border-radius: 6px;
+  padding: 8px;
+  spacing: 0px;
+}
+
+.nm-dialog-item:hover, .nm-dialog-item:focus {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.nm-dialog-item:active {
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.nm-dialog-item:selected {
+  background-color: #1A73E8;
+  color: white;
+}
+
+.nm-dialog-icon {
+  icon-size: 16px;
+}
+
+.nm-dialog-icons {
+  spacing: 8px;
+}
+
+.no-networks-label {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.no-networks-box {
+  spacing: 4px;
+}
+
+/* OSD */
+.osd-window {
+  text-align: center;
+  font-weight: bold;
+  spacing: 8px;
+  padding: 8px 12px;
+  margin-bottom: 8em;
+  border-radius: 9999px;
+}
+
+.osd-window > * {
+  spacing: 8px;
+}
+
+.osd-window StIcon {
+  icon-size: 32px;
+}
+
+.osd-window .osd-monitor-label {
+  font-size: 3em;
+}
+
+.osd-window StLabel:ltr {
+  margin-right: 4px;
+}
+
+.osd-window StLabel:rtl {
+  margin-left: 4px;
+}
+
+.osd-window .level {
+  height: 4px;
+  min-width: 160px;
+  margin-bottom: 4px;
+  -barlevel-height: 4px;
+  -barlevel-background-color: rgba(26, 115, 232, 0.3);
+  -barlevel-active-background-color: #1A73E8;
+  -barlevel-overdrive-color: #E53935;
+  -barlevel-overdrive-separator-width: 3px;
+  -barlevel-border-width: 0;
+}
+
+.osd-window .level:first-child {
+  margin-bottom: 0px;
+}
+
+.osd-window .level:ltr {
+  margin-right: 4px;
+}
+
+.osd-window .level:rtl {
+  margin-left: 4px;
+}
+
+.osd-monitor-label {
+  border-radius: 16px;
+  font-size: 3em;
+  font-weight: bold;
+  margin: 6px;
+  text-align: center;
+  min-width: 1.3em;
+}
+
+/* Pad OSD */
+.pad-osd-window {
+  padding: 32px;
+  background-color: rgba(0, 0, 0, 0.8);
+  border: none;
+}
+
+.pad-osd-window .pad-osd-title-box {
+  spacing: 8px;
+}
+
+.pad-osd-window .pad-osd-title-menu-box {
+  spacing: 4px;
+}
+
+.combo-box-label {
+  width: 15em;
+}
+
+.resize-popup {
+  border-radius: 16px;
+}
+
+/* App Switcher */
+.switcher-popup {
+  padding: 8px;
+  spacing: 16px;
+}
+
+.switcher-list {
+  border-radius: 18px;
+}
+
+.switcher-list .item-box {
+  padding: 8px;
+  border-radius: 10px;
+  border: none;
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.switcher-list .item-box:outlined {
+  background-color: rgba(0, 0, 0, 0.08);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.switcher-list .item-box:selected {
+  background-color: #1A73E8;
+  color: white;
+}
+
+.switcher-list .thumbnail-box {
+  padding: 2px;
+  spacing: 4px;
+}
+
+.switcher-list .thumbnail {
+  width: 256px;
+}
+
+.switcher-list .separator {
+  width: 1px;
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.switcher-list .switcher-list-item-container {
+  spacing: 8px;
+}
+
+.switcher-arrow {
+  border-color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.switcher-arrow:highlighted {
+  color: white;
+}
+
+.input-source-switcher-symbol {
+  font-size: 34pt;
+  width: 96px;
+  height: 96px;
+}
+
+.cycler-highlight {
+  border: 5px solid #1A73E8;
+}
+
+/* Workspace Switcher */
+.workspace-switcher-group {
+  padding: 8px;
+}
+
+.workspace-switcher-container {
+  border-radius: 16px;
+}
+
+.workspace-switcher {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  spacing: 8px;
+}
+
+.ws-switcher-box {
+  height: 50px;
+  background-size: 32px;
+  border: none;
+  background: rgba(0, 0, 0, 0.08);
+  border-radius: 10px;
+}
+
+.ws-switcher-active-up,
+.ws-switcher-active-down,
+.ws-switcher-active-left,
+.ws-switcher-active-right {
+  height: 52px;
+  background-color: #1A73E8;
+  border: none;
+  border-radius: 12px;
+  color: white;
+}
+
+/* Top Bar */
+#panel {
+  font-weight: bold;
+  font-feature-settings: "tnum";
+  padding: 0 !important;
+  transition-duration: 250ms;
+  height: 34px;
+  border: none;
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.65);
+  margin: 2px;
+  border-radius: 9999px;
+}
+
+#panel.unlock-screen, #panel.login-screen, #panel:overview {
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-corner, #panel.login-screen .panel-corner, #panel:overview .panel-corner {
+  -panel-corner-opacity: 0;
+}
+
+#panel .panel-corner {
+  -panel-corner-radius: 0;
+  -panel-corner-background-color: rgba(33, 33, 33, 0.65);
+  -panel-corner-border-width: 0;
+  -panel-corner-border-color: transparent;
+  -panel-corner-opacity: 1;
+  transition-duration: 250ms;
+}
+
+#panel .panel-button#panelActivities {
+  -natural-hpadding: 10px;
+}
+
+#panel .panel-button#panelActivities StBoxLayout {
+  spacing: 4px;
+}
+
+#panel .panel-button#panelActivities .workspace-dot {
+  border-radius: 9999px;
+  min-width: 8px;
+  min-height: 8px;
+  background-color: white;
+}
+
+#panel .panel-button {
+  font-weight: bold;
+  color: white;
+  -natural-hpadding: 9px;
+  -minimum-hpadding: 9px;
+  transition-duration: 150ms;
+  border: 2px solid transparent;
+  border-radius: 9999px;
+  margin: 0;
+}
+
+#panel .panel-button.clock-display {
+  -natural-hpadding: 0 !important;
+  -minimum-hpadding: 0 !important;
+  padding: 0 !important;
+  spacing: 0 !important;
+}
+
+#panel .panel-button.clock-display .clock-display-box {
+  spacing: 0;
+}
+
+#panel .panel-button.clock-display .clock {
+  border-radius: 9999px;
+  padding: 0 8px !important;
+}
+
+#panel .panel-button:hover {
+  background-color: transparent;
+  box-shadow: inset 0 0 0 1000px rgba(255, 255, 255, 0.12);
+}
+
+#panel .panel-button:hover.clock-display {
+  box-shadow: none;
+  background-color: transparent;
+}
+
+#panel .panel-button:hover.clock-display .clock {
+  box-shadow: inset 0 0 0 1000px rgba(255, 255, 255, 0.12);
+}
+
+#panel .panel-button:active, #panel .panel-button:overview, #panel .panel-button:focus, #panel .panel-button:checked {
+  background-color: transparent;
+  box-shadow: inset 0 0 0 1000px rgba(255, 255, 255, 0.3);
+}
+
+#panel .panel-button:active.clock-display, #panel .panel-button:overview.clock-display, #panel .panel-button:focus.clock-display, #panel .panel-button:checked.clock-display {
+  box-shadow: none;
+  background-color: transparent;
+}
+
+#panel .panel-button:active.clock-display .clock, #panel .panel-button:overview.clock-display .clock, #panel .panel-button:focus.clock-display .clock, #panel .panel-button:checked.clock-display .clock {
+  box-shadow: inset 0 0 0 1000px rgba(255, 255, 255, 0.3);
+}
+
+#panel .panel-button .system-status-icon {
+  icon-size: 16px;
+  padding: 4px;
+  margin: 0;
+}
+
+#panel .panel-button .appindicator-trayicons-box {
+  margin: 0 4px;
+}
+
+#panel .panel-button .app-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button {
+  border: 0 none transparent !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  -natural-hpadding: 2px !important;
+  -minimum-hpadding: 2px !important;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .panel-status-menu-box,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .panel-status-menu-box,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .panel-status-menu-box {
+  spacing: 0;
+  padding: 0;
+  margin: 0;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon {
+  border-radius: 9999px;
+  width: 31px;
+  margin: 2px 0;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:hover,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  box-shadow: none;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:active, #panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:overview, #panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:focus, #panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:checked,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:active,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:overview,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:focus,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: none;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button {
+  border-radius: 9999px;
+  width: 31px;
+  margin: 2px 0;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  box-shadow: none;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:active, #panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:overview, #panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:focus, #panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: none;
+}
+
+#panel Gjs_status_keyboard_InputSourceIndicator.panel-button,
+#panel Gjs_appindicatorsupport_rgcjonas_gmail_com_indicatorStatusIcon_IndicatorStatusIcon.panel-button,
+#panel Gjs_appindicatorsupport_rgcjonas_gmail_com_indicatorStatusIcon_AppIndicatorsIndicatorStatusIcon.panel-button {
+  -natural-hpadding: 13px !important;
+  -minimum-hpadding: 13px !important;
+}
+
+#panel .screencast-indicator,
+#panel .remote-access-indicator {
+  color: #FFD600;
+}
+
+#appMenu {
+  spacing: 4px;
+}
+
+#appMenu .label-shadow {
+  color: transparent;
+}
+
+#appMenu .panel-status-menu-box {
+  padding: 0 4px;
+  spacing: 4px;
+}
+
+/* Activities Ripple */
+.ripple-box {
+  background-color: rgba(26, 115, 232, 0.35);
+  width: 52px;
+  height: 52px;
+  border-radius: 0 0 52px 0;
+}
+
+.ripple-box:rtl {
+  border-radius: 0 0 0 52px;
+}
+
+/* OVERVIEW */
+.controls-manager, .secondary-monitor-workspaces {
+  spacing: 8px;
+}
+
+#overviewGroup {
+  background-color: #242424;
+}
+
+.overview-controls {
+  padding-bottom: 32px;
+}
+
+/* Window Picker */
+.window-picker {
+  spacing: 4px;
+}
+
+.window-caption {
+  color: white;
+  background-color: rgba(52, 52, 52, 0.9);
+  border-radius: 9999px;
+  padding: 4px 8px;
+  box-shadow: none;
+  border: none;
+}
+
+.window-close, .screenshot-ui-close-button {
+  background-color: #242424;
+  color: white;
+  border-radius: 9999px;
+  padding: 3px;
+  height: 30px;
+  width: 30px;
+  box-shadow: -1px 1px 5px 0px rgba(0, 0, 0, 0.5);
+  transition-duration: 300ms;
+}
+
+.window-close StIcon, .screenshot-ui-close-button StIcon {
+  icon-size: 24px;
+}
+
+.window-close:hover, .screenshot-ui-close-button:hover {
+  background-color: #4a4a4a;
+}
+
+.window-close:active, .screenshot-ui-close-button:active {
+  color: rgba(255, 255, 255, 0.8);
+  background-color: #171717;
+}
+
+.workspace-background {
+  border-radius: 30px;
+  background-color: #242424;
+  box-shadow: 0 4px 16px 4px rgba(0, 0, 0, 0.15);
+}
+
+.search-entry {
+  min-height: 24px;
+  padding: 4px 4px;
+  width: 320px;
+  border-radius: 9999px;
+  selection-background-color: #1A73E8;
+  selected-color: white !important;
+  caret-color: rgba(0, 0, 0, 0.6);
+  color: rgba(0, 0, 0, 0.6);
+  background-color: #FFFFFF;
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.search-entry:hover {
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.12) !important;
+}
+
+.search-entry:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #1A73E8 !important;
+}
+
+.search-entry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.search-entry .search-entry-icon {
+  icon-size: 16px;
+  padding: 0 4px;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.search-entry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+#overview .search-entry {
+  margin-top: 8px;
+  margin-bottom: 4px;
+  border: none !important;
+  caret-color: rgba(0, 0, 0, 0.75);
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.75);
+  border-color: transparent !important;
+  box-shadow: none !important;
+}
+
+#overview .search-entry:hover {
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.85);
+  box-shadow: none !important;
+}
+
+#overview .search-entry:focus {
+  color: rgba(0, 0, 0, 0.85);
+  border-color: transparent;
+  background-color: rgba(255, 255, 255, 0.95);
+  border: none !important;
+  box-shadow: none !important;
+  selection-background-color: #1A73E8;
+  selected-color: white !important;
+}
+
+#overview .search-entry .search-entry-icon {
+  color: rgba(0, 0, 0, 0.65);
+}
+
+#overview .search-entry:hover .search-entry-icon, #overview .search-entry:focus .search-entry-icon {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+#overview .search-entry StLabel.hint-text {
+  color: rgba(0, 0, 0, 0.35);
+}
+
+/* Search */
+#searchResults {
+  margin: 0 2px;
+}
+
+#searchResultsContent {
+  max-width: 1044px;
+}
+
+.search-section {
+  spacing: 6px;
+}
+
+.search-section .search-section-separator {
+  height: 4px;
+  background-color: transparent;
+}
+
+.search-section-content {
+  background-color: rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  color: white;
+  padding: 8px;
+  margin: 0 6px;
+}
+
+.list-search-result, .search-provider-icon {
+  border-radius: 10px;
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.list-search-result:focus, .search-provider-icon:focus, .list-search-result:hover, .search-provider-icon:hover, .list-search-result:selected, .search-provider-icon:selected {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  transition-duration: 200ms;
+  border-radius: 10px;
+}
+
+.list-search-result:active, .search-provider-icon:active, .list-search-result:checked, .search-provider-icon:checked {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-radius: 10px;
+}
+
+.search-statustext {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.grid-search-results {
+  spacing: 20px;
+  margin: 0 6px;
+}
+
+.search-provider-icon:ltr {
+  margin-right: 2px;
+}
+
+.search-provider-icon:rtl {
+  margin-left: 2px;
+}
+
+.search-provider-icon .list-search-provider-content {
+  spacing: 8px;
+}
+
+.search-provider-icon .list-search-provider-content .list-search-provider-details {
+  width: 120px;
+  margin-top: 0;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.list-search-results {
+  spacing: 4px;
+}
+
+.list-search-result .list-search-result-content {
+  spacing: 4px;
+}
+
+.list-search-result .list-search-result-title {
+  spacing: 8px;
+}
+
+.list-search-result .list-search-result-description {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Dash */
+#dash {
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+#dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 9999px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+#dash .dash-item-container .placeholder {
+  background-image: none;
+  background-size: contain;
+  height: 32px;
+}
+
+#dash .dash-item-container .empty-dash-drop-target {
+  width: 32px;
+  height: 32px;
+}
+
+#dash .dash-item-container .show-apps,
+#dash .dash-item-container .overview-tile,
+#dash .dash-item-container .grid-search-result {
+  background: none;
+  box-shadow: none;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  margin: 0 2px;
+  padding-bottom: 12px;
+}
+
+#dash .dash-item-container .show-apps .overview-icon,
+#dash .dash-item-container .overview-tile .overview-icon,
+#dash .dash-item-container .grid-search-result .overview-icon {
+  border-radius: 9999px;
+  padding: 4px;
+  spacing: 4px;
+  text-align: center;
+  transition-duration: 100ms;
+  background-color: transparent;
+  color: white;
+}
+
+#dash .dash-item-container .show-apps:focus .overview-icon,
+#dash .dash-item-container .overview-tile:focus .overview-icon,
+#dash .dash-item-container .grid-search-result:focus .overview-icon {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#dash .dash-item-container .show-apps:hover .overview-icon,
+#dash .dash-item-container .overview-tile:hover .overview-icon,
+#dash .dash-item-container .grid-search-result:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#dash .dash-item-container .show-apps:active .overview-icon,
+#dash .dash-item-container .overview-tile:active .overview-icon,
+#dash .dash-item-container .grid-search-result:active .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#dash .dash-item-container .show-apps:checked .overview-icon,
+#dash .dash-item-container .overview-tile:checked .overview-icon,
+#dash .dash-item-container .grid-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#dash .dash-item-container .app-grid-running-dot {
+  offset-y: -12px;
+}
+
+#dash .dash-separator {
+  width: 1px;
+  margin-left: 2px;
+  margin-right: 2px;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-separator,
+#dash .dash-background {
+  margin-bottom: 12px;
+}
+
+.dash-label {
+  border-radius: 9999px;
+  padding: 4px 8px;
+  margin: 6px;
+  color: white;
+  background-color: rgba(0, 0, 0, 0.75);
+  border: none;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.32);
+  text-align: center;
+  -y-offset: 0;
+  -x-offset: 0;
+}
+
+/* App Grid */
+.icon-grid {
+  row-spacing: 12px;
+  column-spacing: 12px;
+  max-row-spacing: 36px;
+  max-column-spacing: 36px;
+  page-padding-top: 24px;
+  page-padding-bottom: 24px;
+  page-padding-left: 18px;
+  page-padding-right: 18px;
+}
+
+/* App Icons */
+.overview-tile, .grid-search-result {
+  border-radius: 20px;
+  padding: 12px;
+  spacing: 6px;
+  transition-duration: 150ms;
+  text-align: center;
+  background-color: transparent;
+  color: white;
+  border: 1px solid transparent;
+  box-shadow: inset 0 1px transparent;
+}
+
+.overview-tile:hover, .grid-search-result:hover, .overview-tile:focus, .grid-search-result:focus, .overview-tile:highlighted, .grid-search-result:highlighted, .overview-tile:selected, .grid-search-result:selected {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+  transition-duration: 0ms;
+  border-image: none;
+  background-image: none;
+}
+
+.overview-tile:active, .grid-search-result:active, .overview-tile:checked, .grid-search-result:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+  transition-duration: 150ms;
+  color: white;
+}
+
+.overview-tile .overview-icon.overview-icon-with-label > StBoxLayout, .grid-search-result .overview-icon.overview-icon-with-label > StBoxLayout {
+  spacing: 6px;
+}
+
+.notification-badge {
+  min-width: 16px;
+  min-height: 16px;
+  color: white;
+  background-color: #1A73E8;
+  border-radius: 9999px;
+  padding: 0.2em 0.4em;
+  text-align: center;
+}
+
+.app-folder {
+  background-color: rgba(255, 255, 255, 0.04);
+  border-radius: 20px;
+}
+
+.app-folder:focus, .app-folder:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.app-folder:active, .app-folder:highlighted, .app-folder:selected, .app-folder:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder:insensitive {
+  background-color: transparent;
+}
+
+.app-grid-running-dot {
+  width: 6px;
+  height: 3px;
+  border-radius: 2px;
+  background-color: rgba(255, 255, 255, 0.3);
+  margin-bottom: 1px;
+}
+
+StWidget.focused .app-grid-running-dot {
+  width: 18px;
+  background-color: #1A73E8;
+}
+
+.app-folder-dialog-container {
+  padding-top: 34px;
+}
+
+.app-folder-dialog {
+  border-radius: 40px;
+  border: none;
+  background-color: rgba(36, 36, 36, 0.95);
+  color: white;
+  spacing: 6px;
+  box-shadow: none;
+  outline: none;
+}
+
+.app-folder-dialog .folder-name-container {
+  padding: 24px 36px 0;
+  spacing: 12px;
+  /* FIXME: this is to keep the label in sync with the entry */
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label,
+.app-folder-dialog .folder-name-container .folder-name-entry {
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry {
+  min-height: 28px;
+  padding: 4px;
+  border: none;
+  color: white;
+  background-color: rgba(255, 255, 255, 0.15);
+  caret-color: white;
+  selection-background-color: rgba(255, 255, 255, 0.12) !important;
+  selected-color: white !important;
+  width: 300px;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:hover .search-entry-icon, .app-folder-dialog .folder-name-container .folder-name-entry:focus .search-entry-icon {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:insensitive, .app-folder-dialog .folder-name-container .folder-name-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label {
+  padding: 5px 7px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.app-folder-dialog .folder-name-container .icon-button, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button, .app-folder-dialog .folder-name-container .background-app-item .close-button, .background-app-item .app-folder-dialog .folder-name-container .close-button {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.7);
+  border: none;
+  height: 32px;
+  width: 32px;
+  padding: 4px;
+  border-radius: 9999px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button > StIcon, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button > StIcon, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button > StIcon,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button > StIcon,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button > StIcon, .app-folder-dialog .folder-name-container .background-app-item .close-button > StIcon, .background-app-item .app-folder-dialog .folder-name-container .close-button > StIcon {
+  icon-size: 16px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button:hover, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:hover, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:hover,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:hover,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:hover, .app-folder-dialog .folder-name-container .background-app-item .close-button:hover, .background-app-item .app-folder-dialog .folder-name-container .close-button:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.app-folder-dialog .folder-name-container .icon-button:checked, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:checked, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:checked,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:checked,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:checked, .app-folder-dialog .folder-name-container .background-app-item .close-button:checked, .background-app-item .app-folder-dialog .folder-name-container .close-button:checked, .app-folder-dialog .folder-name-container .icon-button:active, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:active, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:active,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:active,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:active, .app-folder-dialog .folder-name-container .background-app-item .close-button:active, .background-app-item .app-folder-dialog .folder-name-container .close-button:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder-dialog .icon-grid {
+  row-spacing: 12px;
+  column-spacing: 30px;
+  page-padding-top: 0;
+  page-padding-bottom: 0;
+  page-padding-left: 0;
+  page-padding-right: 0;
+}
+
+.app-folder-dialog .page-indicators {
+  margin-bottom: 18px;
+}
+
+.rename-folder-popup .rename-folder-popup-item {
+  spacing: 4px;
+}
+
+.rename-folder-popup .rename-folder-popup-item:ltr, .rename-folder-popup .rename-folder-popup-item:rtl {
+  padding: 0 8px;
+}
+
+.app-menu,
+.app-well-menu {
+  max-width: 27.25em;
+}
+
+.page-indicator {
+  padding: 4px 8px 0;
+}
+
+.page-indicator .page-indicator-icon {
+  width: 10px;
+  height: 10px;
+  border-radius: 10px;
+  background-color: white;
+  transition-duration: 400ms;
+}
+
+.apps-scroll-view {
+  padding: 0;
+}
+
+.system-action-icon {
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  border-radius: 9999px;
+}
+
+.page-navigation-hint.dnd {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.page-navigation-hint.next:ltr, .page-navigation-hint.previous:rtl {
+  background-gradient-start: rgba(255, 255, 255, 0.05);
+  background-gradient-end: transparent;
+  background-gradient-direction: horizontal;
+  border-radius: 15px 0px 0px 15px;
+}
+
+.page-navigation-hint.previous:ltr, .page-navigation-hint.next:rtl {
+  background-gradient-start: transparent;
+  background-gradient-end: rgba(255, 255, 255, 0.05);
+  background-gradient-direction: horizontal;
+  border-radius: 0px 15px 15px 0px;
+}
+
+.page-navigation-arrow {
+  margin: 6px;
+  padding: 18px;
+  width: 24px;
+  height: 24px;
+  border-radius: 9999px;
+  color: white;
+  background-color: transparent;
+}
+
+.page-navigation-arrow:insensitive {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.page-navigation-arrow:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.page-navigation-arrow:active {
+  background-color: rgba(255, 255, 255, 0.24);
+  color: white;
+}
+
+/* Workspace pager */
+.workspace-thumbnails .workspace-thumbnail {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border: none;
+}
+
+.workspace-thumbnails {
+  visible-width: 32px;
+  spacing: 4px;
+  padding: 4px;
+}
+
+.workspace-thumbnails .workspace-thumbnail {
+  border-radius: 3px;
+}
+
+.workspace-thumbnails .placeholder {
+  background-image: url("resource:///org/gnome/shell/theme/dash-placeholder.svg");
+  background-size: contain;
+  width: 18px;
+}
+
+.workspace-thumbnail-indicator {
+  border: 3px solid #1A73E8;
+  border-radius: 3px;
+  padding: 0px;
+}
+
+.ripple-pointer-location {
+  width: 48px;
+  height: 48px;
+  border-radius: 24px;
+  background-color: rgba(165, 200, 246, 0.3);
+  box-shadow: 0 0 2px 2px #77acf1;
+}
+
+.pie-timer {
+  width: 60px;
+  height: 60px;
+  -pie-border-width: 3px;
+  -pie-border-color: #1A73E8;
+  -pie-background-color: rgba(211, 228, 251, 0.3);
+}
+
+.magnifier-zoom-region {
+  border: 2px solid #1A73E8;
+}
+
+.magnifier-zoom-region.full-screen {
+  border-width: 0;
+}
+
+.select-area-rubberband {
+  background-color: rgba(26, 115, 232, 0.3);
+  border: 1px solid #1A73E8;
+}
+
+.user-icon {
+  background-size: contain;
+  color: rgba(255, 255, 255, 0.7);
+  border-radius: 9999px;
+  icon-size: 64px;
+}
+
+.user-icon:hover {
+  color: white;
+}
+
+.user-icon StIcon {
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 99px;
+  padding: 8px;
+  width: 40px;
+  height: 40px;
+}
+
+.user-icon.user-avatar {
+  border: 2px rgba(255, 255, 255, 0.7);
+}
+
+.user-widget.vertical .user-icon {
+  icon-size: 128px;
+}
+
+.user-widget.vertical .user-icon StIcon {
+  padding: 14px;
+  padding-top: 12px;
+  padding-bottom: 16px;
+  width: 88px;
+  height: 88px;
+}
+
+.lightbox {
+  background-color: black;
+}
+
+.flashspot {
+  background-color: white;
+}
+
+.hidden {
+  color: rgba(0, 0, 0, 0);
+}
+
+.caps-lock-warning-label {
+  text-align: center;
+  padding-bottom: 8px;
+  font-size: 9.75pt;
+  font-weight: 400;
+  color: #FFD600;
+}
+
+/* Workspace animation */
+.workspace-animation {
+  background-color: #242424;
+}
+
+/* Tiled window previews */
+.tile-preview {
+  background-color: rgba(26, 115, 232, 0.3);
+  border: 1px solid #1A73E8;
+}
+
+.tile-preview-left.on-primary {
+  border-radius: 11px 0 0 0;
+}
+
+.tile-preview-right.on-primary {
+  border-radius: 0 11px 0 0;
+}
+
+.tile-preview-left.tile-preview-right.on-primary {
+  border-radius: 11px 11px 0 0;
+}
+
+/* On-screen Keyboard */
+#keyboard {
+  background-color: rgba(0, 0, 0, 0.85);
+  border: none;
+  border-top-width: 0;
+  box-shadow: none;
+}
+
+#keyboard .page-indicator {
+  padding: 4px;
+}
+
+#keyboard .page-indicator .page-indicator-icon {
+  width: 8px;
+  height: 8px;
+}
+
+.key-container {
+  padding: 2px;
+  spacing: 2px;
+}
+
+.keyboard-key {
+  min-height: 2em;
+  min-width: 2em;
+  font-size: 14pt;
+  font-weight: bold;
+  border-radius: 10px;
+  border: none;
+  color: inherit;
+  background-color: #FAFAFA;
+  box-shadow: 0 1px rgba(0, 0, 0, 0.2);
+}
+
+.keyboard-key:focus, .keyboard-key:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #e1e1e1;
+}
+
+.keyboard-key:checked, .keyboard-key:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #c7c7c7;
+}
+
+.keyboard-key:grayed {
+  background-color: #242424;
+  color: white;
+  border-color: #242424;
+}
+
+.keyboard-key.default-key {
+  background-color: #BFBFBF;
+  box-shadow: 0 1px rgba(0, 0, 0, 0.2);
+}
+
+.keyboard-key.default-key:focus, .keyboard-key.default-key:hover {
+  color: rgba(0, 0, 0, 0.6);
+  background-color: #FAFAFA;
+}
+
+.keyboard-key.default-key:checked, .keyboard-key.default-key:active {
+  color: rgba(0, 0, 0, 0.6);
+  background-color: #ebebeb;
+}
+
+.keyboard-key.enter-key {
+  background-color: #1A73E8;
+  color: white;
+}
+
+.keyboard-key.enter-key:focus, .keyboard-key.enter-key:hover {
+  color: white;
+  background-color: #3181ea;
+}
+
+.keyboard-key.enter-key:checked, .keyboard-key.enter-key:active {
+  color: white;
+  background-color: #135cbc;
+}
+
+.keyboard-key.shift-key-uppercase {
+  color: #1A73E8;
+}
+
+.keyboard-key StIcon {
+  icon-size: 1.125em;
+}
+
+.keyboard-subkeys {
+  color: inherit;
+  -arrow-border-radius: 10px;
+  -arrow-background-color: rgba(0, 0, 0, 0.45);
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
+  -boxpointer-gap: 5px;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.32);
+}
+
+.emoji-page .keyboard-key {
+  background-color: transparent;
+  border: none;
+  color: initial;
+}
+
+.emoji-panel .keyboard-key:latched {
+  border-color: #3181ea;
+  background-color: #1A73E8;
+}
+
+.word-suggestions {
+  font-size: 14pt;
+  spacing: 12px;
+  min-height: 20pt;
+}
+
+/* Looking Glass */
+#LookingGlassDialog {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: #242424;
+  spacing: 4px;
+  padding: 0;
+  border: none;
+  border-radius: 16px;
+  box-shadow: 0 10px 15px rgba(0, 0, 0, 0.45);
+}
+
+#LookingGlassDialog > #Toolbar {
+  padding: 4px 6px;
+  border: none;
+  border-radius: 16px 16px 0 0;
+  background-color: #3e3e3e;
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+#LookingGlassDialog .labels {
+  spacing: 0;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+#LookingGlassDialog .notebook-tab {
+  -natural-hpadding: 4px;
+  -minimum-hpadding: 4px;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.5);
+  transition-duration: 150ms;
+  padding-left: 12px;
+  padding-right: 12px;
+  min-height: 22px;
+  border-radius: 10px;
+  background-color: transparent;
+}
+
+#LookingGlassDialog .notebook-tab:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.15);
+  text-shadow: none;
+  box-shadow: none;
+}
+
+#LookingGlassDialog .notebook-tab:selected {
+  background-color: rgba(255, 255, 255, 0.1);
+  box-shadow: none;
+  color: white;
+  text-shadow: none;
+}
+
+#LookingGlassDialog StBoxLayout#EvalBox {
+  padding: 4px;
+  spacing: 4px;
+}
+
+#LookingGlassDialog StBoxLayout#ResultsArea {
+  spacing: 4px;
+}
+
+.lg-dialog StEntry {
+  selection-background-color: #1A73E8;
+  selected-color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.lg-dialog .shell-link {
+  color: #1A73E8;
+}
+
+.lg-dialog .shell-link:hover {
+  color: #1A73E8;
+}
+
+.lg-dialog .actor-link {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.lg-dialog .actor-link:hover {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.lg-dialog .actor-link:active {
+  color: rgba(204, 204, 204, 0.5);
+}
+
+.lg-dialog .actor-link StIcon {
+  icon-size: 12px;
+}
+
+.lg-completions-text {
+  font-size: 1em;
+  font-style: italic;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lg-obj-inspector-title {
+  spacing: 4px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lg-obj-inspector-button {
+  min-height: 32px;
+  padding: 4px;
+  border: none;
+  border-radius: 10px;
+  font-size: 9.75pt;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.6);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.lg-obj-inspector-button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.lg-obj-inspector-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.lg-obj-inspector-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.lg-obj-inspector-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.lg-obj-inspector-button:hover {
+  border: none;
+}
+
+#lookingGlassExtensions {
+  padding: 4px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lg-extensions-list {
+  padding: 4px;
+  spacing: 4px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lg-extension {
+  border: none;
+  border-radius: 10px;
+  background-color: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.7);
+  padding: 4px;
+  box-shadow: none;
+}
+
+.lg-extension-name {
+  font-size: 18pt;
+  font-weight: 400;
+  color: white;
+}
+
+.lg-extension-meta {
+  spacing: 4px;
+}
+
+#LookingGlassPropertyInspector {
+  color: white;
+  background: #333333;
+  border: none;
+  border-radius: 10px;
+  padding: 4px;
+  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.32);
+}
+
+#LookingGlassPropertyInspector .window-close, #LookingGlassPropertyInspector .screenshot-ui-close-button {
+  margin: 4px;
+}
+
+.lg-debug-flag-button {
+  color: white;
+}
+
+.lg-debug-flag-button StLabel {
+  padding: 4px, 8px;
+}
+
+.lg-debug-flag-button:hover {
+  color: white;
+}
+
+.lg-debug-flag-button:active {
+  color: #cccccc;
+}
+
+.lg-debug-flags-header {
+  padding-top: 8px;
+  padding: 4px;
+}
+
+.icon-label-button-container {
+  spacing: 4px;
+  font-size: 9pt;
+  font-weight: 400;
+}
+
+.icon-label-button-container StIcon {
+  icon-size: 32px;
+}
+
+.screenshot-ui-panel {
+  color: white;
+  background-color: #212121;
+  border: none;
+  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.32);
+  border-radius: 31px;
+  padding: 12px;
+  padding-bottom: 6px;
+  margin-bottom: 4em;
+  spacing: 8px;
+}
+
+.screenshot-ui-close-button {
+  padding: 4px !important;
+}
+
+.screenshot-ui-close-button.left {
+  margin-left: 6px;
+}
+
+.screenshot-ui-close-button.right {
+  margin-right: 6px;
+}
+
+.screenshot-ui-type-button {
+  min-width: 48px;
+  padding: 8px 12px !important;
+  border-radius: 19px;
+}
+
+.screenshot-ui-capture-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 9999px;
+  border: 4px white;
+  padding: 2px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle {
+  background-color: white;
+  transition-duration: 200ms;
+  border-radius: 9999px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle:hover, .screenshot-ui-capture-button .screenshot-ui-capture-button-circle:focus {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.screenshot-ui-capture-button:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:focus .screenshot-ui-capture-button-circle {
+  background-color: #d9d9d9;
+}
+
+.screenshot-ui-capture-button:active .screenshot-ui-capture-button-circle {
+  background-color: gray;
+}
+
+.screenshot-ui-capture-button:cast .screenshot-ui-capture-button-circle {
+  background-color: #E53935;
+}
+
+.screenshot-ui-capture-button:cast:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:cast:focus .screenshot-ui-capture-button-circle {
+  background-color: #e84f4c;
+}
+
+.screenshot-ui-capture-button:cast:active .screenshot-ui-capture-button-circle {
+  background-color: #da201c;
+}
+
+.screenshot-ui-shot-cast-container {
+  background-color: rgba(0, 0, 0, 0.08);
+  border-radius: 10px;
+  padding: 3px;
+  spacing: 3px;
+}
+
+.screenshot-ui-shot-cast-container:ltr {
+  margin-left: 9px;
+}
+
+.screenshot-ui-shot-cast-container:rtl {
+  margin-right: 9px;
+}
+
+.screenshot-ui-shot-cast-button {
+  padding: 4px 8px;
+  background-color: transparent;
+  border-radius: 7px;
+}
+
+.screenshot-ui-shot-cast-button:hover, .screenshot-ui-shot-cast-button:focus {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.screenshot-ui-shot-cast-button:active {
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.screenshot-ui-shot-cast-button:checked {
+  background-color: white;
+  color: black;
+}
+
+.screenshot-ui-shot-cast-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-show-pointer-button {
+  border-radius: 9999px;
+  padding: 8px !important;
+}
+
+.screenshot-ui-show-pointer-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-selection {
+  border: 2px white;
+}
+
+.screenshot-ui-area-selector-handle {
+  border-radius: 9999px;
+  background-color: white;
+  box-shadow: 0 1px 3px 2px rgba(0, 0, 0, 0.2);
+  width: 24px;
+  height: 24px;
+}
+
+.screenshot-ui-window-selector {
+  background-color: #242424;
+}
+
+.screenshot-ui-window-selector .screenshot-ui-window-selector-window-container {
+  margin: 100px;
+}
+
+.screenshot-ui-window-selector:primary-monitor .screenshot-ui-window-selector-window-container {
+  margin-bottom: 200px;
+}
+
+.screenshot-ui-window-selector-window-border {
+  transition-duration: 200ms;
+  border-radius: 10px;
+  border: 6px transparent;
+}
+
+.screenshot-ui-window-selector-check {
+  transition-duration: 200ms;
+  color: transparent;
+  border-radius: 9999px;
+  border-width: 12px;
+  icon-size: 24px;
+}
+
+.screenshot-ui-window-selector-window:hover .screenshot-ui-window-selector-window-border {
+  border-color: #1151a5;
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-window-border {
+  border-color: #1A73E8;
+  background-color: rgba(26, 115, 232, 0.2);
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-check {
+  color: white;
+  background-color: #1A73E8;
+}
+
+.screenshot-ui-screen-selector {
+  transition-duration: 200ms;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-screen-selector:hover {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-screen-selector:active {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.screenshot-ui-screen-selector:checked {
+  background-color: transparent;
+  border: 2px white;
+}
+
+.screenshot-ui-tooltip {
+  color: white;
+  background-color: #242424;
+  border-radius: 9999px;
+  padding: 4px 8px;
+  text-align: center;
+  -y-offset: 24px;
+}
+
+/* Login Dialog */
+.login-dialog-banner-view {
+  padding-top: 24px;
+  max-width: 23em;
+}
+
+.login-dialog,
+.unlock-dialog {
+  border: none;
+  background-color: transparent;
+}
+
+.login-dialog StEntry,
+.unlock-dialog StEntry {
+  selection-background-color: #1A73E8;
+  selected-color: white !important;
+  caret-color: rgba(0, 0, 0, 0.6);
+  color: rgba(0, 0, 0, 0.6);
+  background-color: #FFFFFF;
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.login-dialog StEntry:focus,
+.unlock-dialog StEntry:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #1A73E8 !important;
+}
+
+.login-dialog StEntry:insensitive,
+.unlock-dialog StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .modal-dialog-button-box,
+.unlock-dialog .modal-dialog-button-box {
+  spacing: 3px;
+}
+
+.login-dialog .modal-dialog-button,
+.unlock-dialog .modal-dialog-button {
+  padding: 4px 18px;
+  box-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:hover, .login-dialog .modal-dialog-button:focus,
+.unlock-dialog .modal-dialog-button:hover,
+.unlock-dialog .modal-dialog-button:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:active,
+.unlock-dialog .modal-dialog-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:insensitive,
+.unlock-dialog .modal-dialog-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default,
+.unlock-dialog .modal-dialog-button:default {
+  color: white;
+  background-color: #1A73E8;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:hover, .login-dialog .modal-dialog-button:default:focus,
+.unlock-dialog .modal-dialog-button:default:hover,
+.unlock-dialog .modal-dialog-button:default:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:active,
+.unlock-dialog .modal-dialog-button:default:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.24);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:insensitive,
+.unlock-dialog .modal-dialog-button:default:insensitive {
+  color: rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .cancel-button,
+.login-dialog .switch-user-button,
+.login-dialog .login-dialog-session-list-button,
+.unlock-dialog .cancel-button,
+.unlock-dialog .switch-user-button,
+.unlock-dialog .login-dialog-session-list-button {
+  padding: 0;
+  border-radius: 99px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background-color: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .cancel-button:hover, .login-dialog .cancel-button:focus,
+.login-dialog .switch-user-button:hover,
+.login-dialog .switch-user-button:focus,
+.login-dialog .login-dialog-session-list-button:hover,
+.login-dialog .login-dialog-session-list-button:focus,
+.unlock-dialog .cancel-button:hover,
+.unlock-dialog .cancel-button:focus,
+.unlock-dialog .switch-user-button:hover,
+.unlock-dialog .switch-user-button:focus,
+.unlock-dialog .login-dialog-session-list-button:hover,
+.unlock-dialog .login-dialog-session-list-button:focus {
+  color: white;
+}
+
+.login-dialog .cancel-button:active,
+.login-dialog .switch-user-button:active,
+.login-dialog .login-dialog-session-list-button:active,
+.unlock-dialog .cancel-button:active,
+.unlock-dialog .switch-user-button:active,
+.unlock-dialog .login-dialog-session-list-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.login-dialog .cancel-button StIcon,
+.login-dialog .switch-user-button StIcon,
+.login-dialog .login-dialog-session-list-button StIcon,
+.unlock-dialog .cancel-button StIcon,
+.unlock-dialog .switch-user-button StIcon,
+.unlock-dialog .login-dialog-session-list-button StIcon {
+  icon-size: 16px;
+}
+
+.login-dialog .caps-lock-warning-label,
+.login-dialog .login-dialog-message-warning,
+.unlock-dialog .caps-lock-warning-label,
+.unlock-dialog .login-dialog-message-warning {
+  color: white;
+}
+
+.login-dialog-logo-bin {
+  padding: 24px 0px;
+}
+
+.login-dialog-banner {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-button-box {
+  width: 23em;
+  spacing: 5px;
+}
+
+.login-dialog-message {
+  text-align: center;
+}
+
+.login-dialog-user-selection-box {
+  padding: 100px 0px;
+}
+
+.login-dialog-not-listed-label {
+  padding-left: 2px;
+  font-size: 1em;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.7);
+  padding-top: 1em;
+}
+
+.login-dialog-not-listed-label:hover {
+  color: white;
+}
+
+.login-dialog-not-listed-label:focus {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.login-dialog-not-listed-button:focus .login-dialog-not-listed-label, .login-dialog-not-listed-button:hover .login-dialog-not-listed-label {
+  color: white;
+}
+
+.login-dialog-user-list-view {
+  -st-vfade-offset: 1em;
+}
+
+.login-dialog-user-list {
+  spacing: 12px;
+  width: 23em;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:selected {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: white;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:logged-in {
+  border-right: 2px solid white;
+}
+
+.login-dialog-user-list-item {
+  border-radius: 10px;
+  padding: 6px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-user-list-item:ltr {
+  padding-right: 1em;
+}
+
+.login-dialog-user-list-item:rtl {
+  padding-left: 1em;
+}
+
+.login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: white;
+}
+
+.login-dialog-user-list-item .login-dialog-timed-login-indicator {
+  height: 2px;
+  margin: 6px 0 0 0;
+  background-color: white;
+}
+
+.login-dialog-user-list-item:focus .login-dialog-timed-login-indicator {
+  background-color: white;
+}
+
+.user-widget-label {
+  color: white;
+}
+
+.user-widget.horizontal .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+  padding-left: 15px;
+}
+
+.user-widget.horizontal .user-widget-label:ltr {
+  padding-left: 14px;
+  text-align: left;
+}
+
+.user-widget.horizontal .user-widget-label:rtl {
+  padding-right: 14px;
+  text-align: right;
+}
+
+.user-widget.vertical .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  text-align: center;
+  font-weight: normal;
+  padding-top: 16px;
+}
+
+.login-dialog-prompt-layout {
+  padding-top: 24px;
+  padding-bottom: 12px;
+  spacing: 8px;
+  width: 23em;
+}
+
+.login-dialog-prompt-entry {
+  height: 1.5em;
+}
+
+.login-dialog-prompt-label {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 1em;
+  padding-top: 1em;
+}
+
+/* Screen Shield */
+.unlock-dialog-clock {
+  color: white;
+  font-weight: 300;
+  text-align: center;
+  spacing: 24px;
+  padding-bottom: 2.5em;
+}
+
+.unlock-dialog-clock-time {
+  font-size: 64pt;
+  padding-top: 42px;
+  font-feature-settings: "tnum";
+}
+
+.unlock-dialog-clock-date {
+  font-size: 16pt;
+  font-weight: normal;
+}
+
+.unlock-dialog-clock-hint {
+  font-weight: normal;
+  padding-top: 48px;
+}
+
+.unlock-dialog-notifications-container {
+  margin: 12px 0;
+  spacing: 6px;
+  width: 23em;
+  background-color: transparent;
+}
+
+.unlock-dialog-notifications-container .summary-notification-stack-scrollview {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.unlock-dialog-notifications-container .notification,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source {
+  padding: 12px 6px;
+  border: none;
+  background-color: rgba(52, 52, 52, 0.9);
+  color: white;
+  border-radius: 10px;
+}
+
+.unlock-dialog-notifications-container .notification.critical,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source.critical {
+  background-color: rgba(36, 36, 36, 0.9);
+}
+
+.unlock-dialog-notification-label {
+  padding: 0px 0px 0px 12px;
+}
+
+.unlock-dialog-notification-count-text {
+  weight: bold;
+  padding: 0 6px;
+  color: rgba(52, 52, 52, 0.9);
+  background-color: rgba(255, 255, 255, 0.7);
+  border-radius: 99px;
+  margin-right: 12px;
+}
+
+.screen-shield-background {
+  background: black;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.6);
+}
+
+#lockDialogGroup {
+  background-color: #242424;
+}
+
+#unlockDialogNotifications StButton#vhandle, #unlockDialogNotifications StButton#hhandle {
+  background-color: rgba(52, 52, 52, 0.2);
+}
+
+#unlockDialogNotifications StButton#vhandle:hover, #unlockDialogNotifications StButton#vhandle:focus, #unlockDialogNotifications StButton#hhandle:hover, #unlockDialogNotifications StButton#hhandle:focus {
+  background-color: rgba(52, 52, 52, 0.4);
+}
+
+#unlockDialogNotifications StButton#vhandle:active, #unlockDialogNotifications StButton#hhandle:active {
+  background-color: rgba(26, 115, 232, 0.5);
+}
+
+.bottom #dashtodockDashScrollview,
+.top #dashtodockDashScrollview {
+  -st-hfade-offset: 24px;
+}
+
+.left #dashtodockDashScrollview,
+.right #dashtodockDashScrollview {
+  -st-vfade-offset: 24px;
+}
+
+#dashtodockContainer {
+  background: transparent;
+}
+
+#dashtodockContainer .number-overlay {
+  min-width: 1.2em;
+  min-height: 1.2em;
+  color: white;
+  background-color: rgba(0, 0, 0, 0.75);
+  text-align: center;
+  padding: 0.2em 0.4em;
+}
+
+#dashtodockContainer .notification-badge {
+  min-width: 16px;
+  min-height: 16px;
+  color: white;
+  background-color: #1A73E8;
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.25);
+  border-radius: 9999px;
+  margin: 2px 3px 5px;
+  padding: 0.2em 0.4em;
+  font-weight: bold;
+  text-align: center;
+}
+
+#dashtodockContainer.top #dash .dash-background {
+  border-radius: 9999px !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash, #dashtodockContainer.top.shrink.straight-corner #dash, #dashtodockContainer.top.extended #dash, #dashtodockContainer.top.shrink.extended #dash {
+  margin: 0 !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .dash-background, #dashtodockContainer.top.shrink.straight-corner #dash .dash-background, #dashtodockContainer.top.extended #dash .dash-background, #dashtodockContainer.top.shrink.extended #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .show-apps,
+#dashtodockContainer.top.straight-corner #dash .overview-tile,
+#dashtodockContainer.top.straight-corner #dash .grid-search-result, #dashtodockContainer.top.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.top.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.top.extended #dash .show-apps,
+#dashtodockContainer.top.extended #dash .overview-tile,
+#dashtodockContainer.top.extended #dash .grid-search-result, #dashtodockContainer.top.shrink.extended #dash .show-apps,
+#dashtodockContainer.top.shrink.extended #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.bottom #dash .dash-background {
+  border-radius: 9999px !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash, #dashtodockContainer.bottom.shrink.straight-corner #dash, #dashtodockContainer.bottom.extended #dash, #dashtodockContainer.bottom.shrink.extended #dash {
+  margin: 0 !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .dash-background, #dashtodockContainer.bottom.shrink.straight-corner #dash .dash-background, #dashtodockContainer.bottom.extended #dash .dash-background, #dashtodockContainer.bottom.shrink.extended #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.straight-corner #dash .overview-tile,
+#dashtodockContainer.bottom.straight-corner #dash .grid-search-result, #dashtodockContainer.bottom.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.bottom.extended #dash .show-apps,
+#dashtodockContainer.bottom.extended #dash .overview-tile,
+#dashtodockContainer.bottom.extended #dash .grid-search-result, #dashtodockContainer.bottom.shrink.extended #dash .show-apps,
+#dashtodockContainer.bottom.shrink.extended #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.left #dash .dash-background {
+  border-radius: 9999px !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash, #dashtodockContainer.left.shrink.straight-corner #dash, #dashtodockContainer.left.extended #dash, #dashtodockContainer.left.shrink.extended #dash {
+  margin: 0 !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .dash-background, #dashtodockContainer.left.shrink.straight-corner #dash .dash-background, #dashtodockContainer.left.extended #dash .dash-background, #dashtodockContainer.left.shrink.extended #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .show-apps,
+#dashtodockContainer.left.straight-corner #dash .overview-tile,
+#dashtodockContainer.left.straight-corner #dash .grid-search-result, #dashtodockContainer.left.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.left.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.left.extended #dash .show-apps,
+#dashtodockContainer.left.extended #dash .overview-tile,
+#dashtodockContainer.left.extended #dash .grid-search-result, #dashtodockContainer.left.shrink.extended #dash .show-apps,
+#dashtodockContainer.left.shrink.extended #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.right #dash .dash-background {
+  border-radius: 9999px !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash, #dashtodockContainer.right.shrink.straight-corner #dash, #dashtodockContainer.right.extended #dash, #dashtodockContainer.right.shrink.extended #dash {
+  margin: 0 !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .dash-background, #dashtodockContainer.right.shrink.straight-corner #dash .dash-background, #dashtodockContainer.right.extended #dash .dash-background, #dashtodockContainer.right.shrink.extended #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .show-apps,
+#dashtodockContainer.right.straight-corner #dash .overview-tile,
+#dashtodockContainer.right.straight-corner #dash .grid-search-result, #dashtodockContainer.right.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.right.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.right.extended #dash .show-apps,
+#dashtodockContainer.right.extended #dash .overview-tile,
+#dashtodockContainer.right.extended #dash .grid-search-result, #dashtodockContainer.right.shrink.extended #dash .show-apps,
+#dashtodockContainer.right.shrink.extended #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.extended .dash-background, #dashtodockContainer.straight-corner .dash-background {
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.shrink .dash-background {
+  padding: 2px !important;
+}
+
+#dashtodockContainer.shrink .show-apps,
+#dashtodockContainer.shrink .overview-tile,
+#dashtodockContainer.shrink .grid-search-result {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.shrink.extended .dash-background {
+  border-radius: 0;
+}
+
+#dashtodockContainer #dash, #dashtodockContainer:overview #dash {
+  background: transparent;
+}
+
+#dashtodockContainer.left #dash, #dashtodockContainer.right #dash {
+  margin-top: 0 !important;
+  padding: 12px !important;
+}
+
+#dashtodockContainer.left #dash #dashtodockDashContainer, #dashtodockContainer.right #dash #dashtodockDashContainer {
+  padding: 10px 0 !important;
+}
+
+#dashtodockContainer.left .show-apps,
+#dashtodockContainer.left .overview-tile,
+#dashtodockContainer.left .grid-search-result, #dashtodockContainer.right .show-apps,
+#dashtodockContainer.right .overview-tile,
+#dashtodockContainer.right .grid-search-result {
+  padding: 2px 4px !important;
+}
+
+#dashtodockContainer.left .dash-background, #dashtodockContainer.right .dash-background {
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.left.shrink #dash #dashtodockDashContainer, #dashtodockContainer.right.shrink #dash #dashtodockDashContainer {
+  padding: 2px 0 !important;
+}
+
+#dashtodockContainer.left.shrink .dash-background, #dashtodockContainer.right.shrink .dash-background {
+  padding: 2px !important;
+}
+
+#dashtodockContainer.left.shrink .show-apps,
+#dashtodockContainer.left.shrink .overview-tile,
+#dashtodockContainer.left.shrink .grid-search-result, #dashtodockContainer.right.shrink .show-apps,
+#dashtodockContainer.right.shrink .overview-tile,
+#dashtodockContainer.right.shrink .grid-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer, #dashtodockContainer.right.extended #dash #dashtodockDashContainer, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.right.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child {
+  padding-top: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.right.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child {
+  padding-bottom: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.right.extended #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer > :first-child .show-apps {
+  padding-bottom: 4px !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.right.extended #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer > :last-child .show-apps {
+  padding-bottom: 20px !important;
+}
+
+#dashtodockContainer.left.extended.shrink .dash-background, #dashtodockContainer.left.straight-corner.shrink .dash-background, #dashtodockContainer.right.extended.shrink .dash-background, #dashtodockContainer.right.straight-corner.shrink .dash-background {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended.shrink .show-apps,
+#dashtodockContainer.left.extended.shrink .overview-tile,
+#dashtodockContainer.left.extended.shrink .grid-search-result, #dashtodockContainer.left.straight-corner.shrink .show-apps,
+#dashtodockContainer.left.straight-corner.shrink .overview-tile,
+#dashtodockContainer.left.straight-corner.shrink .grid-search-result, #dashtodockContainer.right.extended.shrink .show-apps,
+#dashtodockContainer.right.extended.shrink .overview-tile,
+#dashtodockContainer.right.extended.shrink .grid-search-result, #dashtodockContainer.right.straight-corner.shrink .show-apps,
+#dashtodockContainer.right.straight-corner.shrink .overview-tile,
+#dashtodockContainer.right.straight-corner.shrink .grid-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended .overview-tile, #dashtodockContainer.left.extended .grid-search-result, #dashtodockContainer.left.straight-corner .overview-tile, #dashtodockContainer.left.straight-corner .grid-search-result, #dashtodockContainer.right.extended .overview-tile, #dashtodockContainer.right.extended .grid-search-result, #dashtodockContainer.right.straight-corner .overview-tile, #dashtodockContainer.right.straight-corner .grid-search-result {
+  padding: 2px 12px !important;
+}
+
+#dashtodockContainer.left.extended .show-apps, #dashtodockContainer.left.straight-corner .show-apps, #dashtodockContainer.right.extended .show-apps, #dashtodockContainer.right.straight-corner .show-apps {
+  padding: 2px 12px 24px !important;
+}
+
+#dashtodockContainer.top .dash-background, #dashtodockContainer.bottom .dash-background {
+  padding: 12px 10px !important;
+}
+
+#dashtodockContainer.top .show-apps,
+#dashtodockContainer.top .overview-tile,
+#dashtodockContainer.top .grid-search-result, #dashtodockContainer.bottom .show-apps,
+#dashtodockContainer.bottom .overview-tile,
+#dashtodockContainer.bottom .grid-search-result {
+  margin: 0 2px !important;
+  padding-bottom: 12px !important;
+}
+
+#dashtodockContainer.top .show-apps .overview-icon,
+#dashtodockContainer.top .overview-tile .overview-icon,
+#dashtodockContainer.top .grid-search-result .overview-icon, #dashtodockContainer.bottom .show-apps .overview-icon,
+#dashtodockContainer.bottom .overview-tile .overview-icon,
+#dashtodockContainer.bottom .grid-search-result .overview-icon {
+  padding: 4px !important;
+  spacing: 4px !important;
+}
+
+#dashtodockContainer.top.shrink .dash-background, #dashtodockContainer.bottom.shrink .dash-background {
+  padding: 2px 1px !important;
+}
+
+#dashtodockContainer.top.shrink .show-apps,
+#dashtodockContainer.top.shrink .overview-tile,
+#dashtodockContainer.top.shrink .grid-search-result, #dashtodockContainer.bottom.shrink .show-apps,
+#dashtodockContainer.bottom.shrink .overview-tile,
+#dashtodockContainer.bottom.shrink .grid-search-result {
+  margin: 0 !important;
+  padding: 0 1px 12px !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child {
+  padding-left: 0 !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child {
+  padding-right: 0 !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer > :first-child .show-apps {
+  padding-left: 0 !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer > :last-child .show-apps {
+  padding-right: 16px !important;
+}
+
+#dashtodockContainer.top.extended.shrink .dash-background, #dashtodockContainer.top.straight-corner.shrink .dash-background, #dashtodockContainer.bottom.extended.shrink .dash-background, #dashtodockContainer.bottom.straight-corner.shrink .dash-background {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.extended.shrink .show-apps,
+#dashtodockContainer.top.extended.shrink .overview-tile,
+#dashtodockContainer.top.extended.shrink .grid-search-result, #dashtodockContainer.top.straight-corner.shrink .show-apps,
+#dashtodockContainer.top.straight-corner.shrink .overview-tile,
+#dashtodockContainer.top.straight-corner.shrink .grid-search-result, #dashtodockContainer.bottom.extended.shrink .show-apps,
+#dashtodockContainer.bottom.extended.shrink .overview-tile,
+#dashtodockContainer.bottom.extended.shrink .grid-search-result, #dashtodockContainer.bottom.straight-corner.shrink .show-apps,
+#dashtodockContainer.bottom.straight-corner.shrink .overview-tile,
+#dashtodockContainer.bottom.straight-corner.shrink .grid-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.extended .dash-separator, #dashtodockContainer.top.straight-corner .dash-separator, #dashtodockContainer.bottom.extended .dash-separator, #dashtodockContainer.bottom.straight-corner .dash-separator {
+  margin: 0 8px !important;
+}
+
+#dashtodockContainer.top.extended .show-apps,
+#dashtodockContainer.top.extended .overview-tile,
+#dashtodockContainer.top.extended .grid-search-result, #dashtodockContainer.top.straight-corner .show-apps,
+#dashtodockContainer.top.straight-corner .overview-tile,
+#dashtodockContainer.top.straight-corner .grid-search-result, #dashtodockContainer.bottom.extended .show-apps,
+#dashtodockContainer.bottom.extended .overview-tile,
+#dashtodockContainer.bottom.extended .grid-search-result, #dashtodockContainer.bottom.straight-corner .show-apps,
+#dashtodockContainer.bottom.straight-corner .overview-tile,
+#dashtodockContainer.bottom.straight-corner .grid-search-result {
+  padding: 12px 2px !important;
+}
+
+#dashtodockContainer #dash .dash-background {
+  background-color: rgba(33, 33, 33, 0.65);
+}
+
+#dashtodockContainer #dash .app-grid-running-dot {
+  margin-bottom: 3px !important;
+  margin-top: 0 !important;
+  offset-y: 0 !important;
+}
+
+#dashtodockContainer #dash StWidget.focused .app-grid-running-dot {
+  background-color: #1A73E8;
+}
+
+#dashtodockContainer.opaque #dash .dash-background {
+  background-color: #212121;
+}
+
+#dashtodockContainer.transparent #dash .dash-background {
+  background-color: rgba(33, 33, 33, 0.65);
+}
+
+#dashtodockContainer:overview #dash {
+  background: none;
+}
+
+#dashtodockContainer:overview #dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#dashtodockContainer:overview #dash StWidget.focused .app-grid-running-dot {
+  background-color: #1A73E8;
+}
+
+#dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
+  background-color: transparent !important;
+  box-shadow: none !important;
+}
+
+#dashtodockContainer.opaque:overview .dash-background, #dashtodockContainer.transparent:overview .dash-background {
+  background-color: transparent !important;
+}
+
+#dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
+  background: none;
+}
+
+#dashtodockContainer.running-dots .dash-item-container > StButton, #dashtodockContainer.dashtodock .dash-item-container > StButton {
+  transition-duration: 250ms;
+  background-size: contain;
+}
+
+#dashtodockContainer.shrink .dash-item-container > StButton, #dashtodockContainer.dashtodock .dash-item-container > StButton {
+  padding: 1px 2px;
+}
+
+#dashtodockContainer.extended .overview-tile .overview-icon, #dashtodockContainer.extended .grid-search-result .overview-icon,
+#dashtodockContainer.extended .show-apps .overview-icon, #dashtodockContainer.extended:overview .overview-tile .overview-icon,
+#dashtodockContainer.extended:overview .show-apps .overview-icon {
+  border-radius: 10px;
+}
+
+#dashtodockContainer .metro .overview-icon {
+  border-radius: 0;
+}
+
+.dashtodock-app-well-preview-menu-item {
+  padding: 1em 1em 0.5em 1em;
+}
+
+#dashtodockPreviewSeparator.popup-separator-menu-item-horizontal {
+  width: 1px;
+  height: auto;
+  border-right-width: 1px;
+  margin: 32px 0;
+}
+
+.dash-label.bottom {
+  margin-bottom: 16px !important;
+}
+
+.dashtopanelMainPanel {
+  border-radius: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+.dashtopanelMainPanel .dash-background {
+  background-color: rgba(33, 33, 33, 0.65);
+  margin-bottom: 0 !important;
+  padding: 0 !important;
+  border-radius: 0 !important;
+}
+
+.dashtopanelMainPanel .overview-tile, .dashtopanelMainPanel .grid-search-result {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .overview-tile .overview-icon, .dashtopanelMainPanel .grid-search-result .overview-icon {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .show-apps {
+  color: white !important;
+  border-radius: 0 !important;
+}
+
+.dashtopanelMainPanel .show-apps:hover {
+  background: rgba(255, 255, 255, 0.12) !important;
+}
+
+.dashtopanelMainPanel .show-apps:active {
+  background: rgba(255, 255, 255, 0.3) !important;
+}
+
+.dashtopanelMainPanel .panel-button, .dashtopanelMainPanel .panel-button.clock-display .clock {
+  border-radius: 7px !important;
+  margin: 0 !important;
+}
+
+.dashtopanelMainPanel .arcmenu-menu-button {
+  border-radius: 5px !important;
+  padding: 8px 6px !important;
+}
+
+.popup-menu.panel-menu .popup-menu-content, .popup-menu.panel-menu.quick-settings .popup-menu-content {
+  margin-bottom: 2px !important;
+}
+
+.dashtopanelSecondaryMenu {
+  border-radius: 12px !important;
+}
+
+#preview-menu {
+  margin: 4px !important;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2) !important;
+  border-radius: 12px !important;
+  padding: 0 !important;
+}
+
+#dashtopanelPreviewScrollview {
+  padding: 12px 0 !important;
+  border-radius: 12px !important;
+  background: #0c0c0c !important;
+}
+
+.openweather-button, .openweather-button-action, .openweather-menu-button-container, .openweather-button-box {
+  border: 1px solid transparent;
+}
+
+.openweather-provider {
+  padding: 0 16px;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.6);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.openweather-provider:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.openweather-provider:focus {
+  color: rgba(0, 0, 0, 0.87);
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.openweather-provider:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.openweather-current-icon, .openweather-current-summary, .openweather-current-summarybox {
+  background: none;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.openweather-current-databox-values {
+  background: none;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.openweather-current-databox-captions {
+  background: none;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.openweather-forecast-icon, .openweather-forecast-summary {
+  background: none;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.openweather-forecast-day, .openweather-forecast-temperature {
+  background: none;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.openweather-sunrise-icon, .openweather-sunset-icon, .openweather-build-icon {
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.popup-sub-menu .openweather-current-icon, .popup-sub-menu .openweather-current-summary, .popup-sub-menu .openweather-current-summarybox {
+  background: none;
+  color: rgba(0, 0, 0, 0.95);
+}
+
+.popup-sub-menu .openweather-current-databox-values {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.popup-sub-menu .openweather-current-databox-captions {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.popup-sub-menu .openweather-forecast-icon, .popup-sub-menu .openweather-forecast-summary {
+  color: rgba(0, 0, 0, 0.85);
+}
+
+.popup-sub-menu .openweather-forecast-day, .popup-sub-menu .openweather-forecast-temperature {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.popup-sub-menu .openweather-sunrise-icon, .popup-sub-menu .openweather-sunset-icon, .popup-sub-menu .openweather-build-icon {
+  color: rgba(0, 0, 0, 0.85);
+}
+
+.arcmenu-menu-button,
+.arcmenu-button {
+  border-width: 0 !important;
+  border-radius: 9999px !important;
+}
+
+.cosmic-solid-bg {
+  background-color: #242424;
+}
+
+.cosmic-dock #dock {
+  background-color: transparent;
+}
+
+.cosmic-dock #dock .dash-background {
+  background-color: rgba(33, 33, 33, 0.65);
+}
+
+.cosmic-dock.extended #dash {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding: 0 0;
+}
+
+.cosmic-dock.extended #dash .dash-background {
+  border-radius: 0;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.overview-components-transparent .search-entry,
+.overview-components-light .search-entry,
+.overview-components-dark .search-entry {
+  caret-color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.overview-components-transparent .search-entry .search-entry-icon,
+.overview-components-light .search-entry .search-entry-icon,
+.overview-components-dark .search-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.overview-components-transparent .search-entry StLabel.hint-text,
+.overview-components-light .search-entry StLabel.hint-text,
+.overview-components-dark .search-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.35) !important;
+}

--- a/src/gnome-shell/shell-48-0/gnome-shell-Compact.scss
+++ b/src/gnome-shell/shell-48-0/gnome-shell-Compact.scss
@@ -1,0 +1,10 @@
+$variant: 'light';
+$topbar: 'dark';
+$compact: 'true';
+
+@import '../../_sass/variables';
+@import '../../_sass/colors';
+@import '../../_sass/gnome-shell/drawing';
+@import '../../_sass/gnome-shell/common';
+@import '../../_sass/gnome-shell/widgets-48-0';
+@import '../../_sass/gnome-shell/extensions-46-0';

--- a/src/gnome-shell/shell-48-0/gnome-shell-Dark-Compact.css
+++ b/src/gnome-shell/shell-48-0/gnome-shell-Dark-Compact.css
@@ -1,0 +1,5097 @@
+/* This stylesheet is generated, DO NOT EDIT */
+stage {
+  font-size: 9.75pt;
+  font-weight: 400;
+  color: white;
+}
+
+.search-statustext {
+  font-size: 45px;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.modal-dialog .modal-dialog-linked-button, .hotplug-notification-item {
+  border: none;
+  margin-bottom: 4px;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.04);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+  font-size: 9.75pt;
+  font-weight: 500;
+}
+
+.modal-dialog .modal-dialog-linked-button:hover, .hotplug-notification-item:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.modal-dialog .modal-dialog-linked-button:active, .hotplug-notification-item:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.24);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+  color: white !important;
+}
+
+.modal-dialog .modal-dialog-linked-button:insensitive, .hotplug-notification-item:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: rgba(255, 255, 255, 0.04);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.modal-dialog .modal-dialog-linked-button:focus, .hotplug-notification-item:focus {
+  color: #3281EA;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.modal-dialog .modal-dialog-linked-button:focus:active, .hotplug-notification-item:focus:active {
+  color: white;
+}
+
+.modal-dialog .modal-dialog-linked-button:first-child, .hotplug-notification-item:first-child {
+  margin-left: 4px !important;
+  margin-right: 0 !important;
+  border-radius: 9999px 0 0 9999px;
+}
+
+.modal-dialog .modal-dialog-linked-button:last-child, .hotplug-notification-item:last-child {
+  margin-left: 0 !important;
+  margin-right: 4px !important;
+  border-right-width: 0;
+  border-radius: 0 9999px 9999px 0;
+}
+
+.modal-dialog .modal-dialog-linked-button:first-child:last-child, .hotplug-notification-item:first-child:last-child {
+  margin: 0 4px 4px 4px !important;
+  border-right-width: 0;
+  border-radius: 9999px;
+}
+
+.screenshot-ui-show-pointer-button, .screenshot-ui-type-button {
+  border: none;
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:insensitive, .screenshot-ui-type-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: #242424;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:focus, .screenshot-ui-type-button:focus {
+  color: #3281EA;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.screenshot-ui-show-pointer-button:focus:active, .screenshot-ui-type-button:focus:active {
+  color: white;
+}
+
+.screenshot-ui-show-pointer-button:hover, .screenshot-ui-type-button:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:active, .screenshot-ui-type-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.24);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:outlined, .screenshot-ui-type-button:outlined, .screenshot-ui-show-pointer-button:checked, .screenshot-ui-type-button:checked {
+  color: white;
+  background-color: #3281EA;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.workspace-switcher-container, .switcher-list, .resize-popup, .osd-monitor-label, .osd-window {
+  color: white;
+  background-color: #212121;
+  border: none;
+  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.32);
+  padding: 8px;
+}
+
+/* General Typography */
+.message-list .message-list-placeholder {
+  font-weight: 800;
+  font-size: 15pt;
+}
+
+.quick-toggle-menu .header .title {
+  font-weight: 700;
+  font-size: 15pt;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  font-weight: 700;
+  font-size: 13pt;
+}
+
+.background-app-item .title, .message-list-controls {
+  font-weight: 700;
+  font-size: 11pt;
+}
+
+.quick-toggle-menu .header .subtitle, .app-menu .popup-inactive-menu-item:first-child > StLabel {
+  font-weight: 700;
+  font-size: 9pt;
+}
+
+.background-app-item .subtitle, .message .message-header .message-header-content .event-time {
+  font-weight: 400;
+  font-size: 9pt;
+}
+
+/* WIDGETS */
+.shell-link {
+  border-radius: 10px;
+  color: #3281EA;
+  background-color: transparent;
+}
+
+.shell-link:hover {
+  color: #3281EA;
+  background-color: rgba(50, 129, 234, 0.15);
+}
+
+.shell-link:active {
+  color: #3281EA;
+  background-color: rgba(50, 129, 234, 0.3);
+}
+
+.lowres-icon {
+  icon-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.icon-dropshadow {
+  icon-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+}
+
+/* Entries */
+StEntry {
+  min-height: 32px;
+  padding: 0 8px;
+  border-radius: 9999px;
+  border-width: 0;
+  selection-background-color: rgba(50, 129, 234, 0.35) !important;
+  selected-color: #3281EA !important;
+  font-size: 11.25pt;
+  font-weight: 400;
+  caret-color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.12);
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+StEntry:hover {
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.12) !important;
+}
+
+StEntry:focus {
+  color: white;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #3281EA !important;
+}
+
+StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+StEntry StIcon.capslock-warning {
+  icon-size: 16px;
+  warning-color: #FBC02D;
+  padding: 0 4px;
+}
+
+StEntry StIcon.peek-password {
+  icon-size: 16px;
+  padding: 0 4px;
+}
+
+StEntry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Buttons */
+.icon-button.flat, .background-app-item .flat.close-button, .message .message-header .flat.message-expand-button,
+.message .message-header .flat.message-close-button, .button.flat {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button.flat:focus, .background-app-item .flat.close-button:focus, .message .message-header .flat.message-expand-button:focus,
+.message .message-header .flat.message-close-button:focus, .button.flat:focus {
+  color: white;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.icon-button.flat:hover, .background-app-item .flat.close-button:hover, .message .message-header .flat.message-expand-button:hover,
+.message .message-header .flat.message-close-button:hover, .button.flat:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button.flat:selected, .background-app-item .flat.close-button:selected, .message .message-header .flat.message-expand-button:selected,
+.message .message-header .flat.message-close-button:selected, .button.flat:selected, .icon-button.flat:active, .background-app-item .flat.close-button:active, .message .message-header .flat.message-expand-button:active,
+.message .message-header .flat.message-close-button:active, .button.flat:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button.flat:checked, .background-app-item .flat.close-button:checked, .message .message-header .flat.message-expand-button:checked,
+.message .message-header .flat.message-close-button:checked, .button.flat:checked {
+  color: white;
+  background-color: #3281EA;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button.flat:insensitive, .background-app-item .flat.close-button:insensitive, .message .message-header .flat.message-expand-button:insensitive,
+.message .message-header .flat.message-close-button:insensitive, .button.flat:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.keyboard-brightness-level .button:checked, .icon-button.default, .background-app-item .default.close-button, .message .message-header .default.message-expand-button,
+.message .message-header .default.message-close-button, .button.default {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: #3281EA;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.keyboard-brightness-level .button:focus:checked, .icon-button.default:focus, .background-app-item .default.close-button:focus, .message .message-header .default.message-expand-button:focus,
+.message .message-header .default.message-close-button:focus, .button.default:focus {
+  color: #3281EA;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.keyboard-brightness-level .button:focus:active:checked, .icon-button.default:focus:active, .background-app-item .default.close-button:focus:active, .message .message-header .default.message-expand-button:focus:active,
+.message .message-header .default.message-close-button:focus:active, .button.default:focus:active {
+  color: white;
+}
+
+.keyboard-brightness-level .button:hover:checked, .icon-button.default:hover, .background-app-item .default.close-button:hover, .message .message-header .default.message-expand-button:hover,
+.message .message-header .default.message-close-button:hover, .button.default:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.keyboard-brightness-level .button:insensitive:checked, .icon-button.default:insensitive, .background-app-item .default.close-button:insensitive, .message .message-header .default.message-expand-button:insensitive,
+.message .message-header .default.message-close-button:insensitive, .button.default:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: #3281EA;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.keyboard-brightness-level .button:active:checked, .icon-button.default:active, .background-app-item .default.close-button:active, .message .message-header .default.message-expand-button:active,
+.message .message-header .default.message-close-button:active, .button.default:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.24);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button {
+  min-height: 24px;
+  padding: 4px 8px;
+  border: none;
+  border-radius: 10px;
+  text-align: center;
+  font-size: 9.75pt;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:checked {
+  color: white;
+  background-color: #3281EA;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:focus {
+  color: white;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.icon-button, .background-app-item .close-button, .message .message-header .message-expand-button,
+.message .message-header .message-close-button {
+  min-height: 16px;
+  min-width: 16px;
+  padding: 8px;
+  border-radius: 9999px;
+  border: none;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:hover, .background-app-item .close-button:hover, .message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:active, .background-app-item .close-button:active, .message .message-header .message-expand-button:active,
+.message .message-header .message-close-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:checked, .background-app-item .close-button:checked, .message .message-header .message-expand-button:checked,
+.message .message-header .message-close-button:checked {
+  color: white;
+  background-color: #3281EA;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:insensitive, .background-app-item .close-button:insensitive, .message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:focus, .background-app-item .close-button:focus, .message .message-header .message-expand-button:focus,
+.message .message-header .message-close-button:focus {
+  color: white;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.icon-button StIcon, .background-app-item .close-button StIcon, .message .message-header .message-expand-button StIcon,
+.message .message-header .message-close-button StIcon {
+  icon-size: 16px;
+  -st-icon-style: symbolic;
+}
+
+/* Check Boxes */
+.check-box StBoxLayout {
+  spacing: .8em;
+}
+
+.check-box StBin {
+  width: 24px;
+  height: 24px;
+  padding: 4px;
+  border-radius: 100px;
+  background-image: url("assets/checkbox-off.svg");
+}
+
+.check-box:focus StBin {
+  background-image: url("assets/checkbox-off.svg");
+}
+
+.check-box:hover StBin {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.check-box:active StBin {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.check-box:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:focus:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:hover:checked StBin {
+  background-color: rgba(50, 129, 234, 0.15);
+}
+
+.check-box:active:checked StBin {
+  background-color: rgba(50, 129, 234, 0.3);
+}
+
+/* Switches */
+.toggle-switch {
+  width: 44px;
+  height: 26px;
+  background-size: contain;
+  background-image: url("assets/toggle-off.svg");
+}
+
+.toggle-switch:checked {
+  background-image: url("assets/toggle-on.svg");
+}
+
+.popup-sub-menu .toggle-switch, .quick-toggle-menu .toggle-switch {
+  background-image: url("assets/menu-toggle-off.svg");
+}
+
+.popup-sub-menu .toggle-switch:checked, .quick-toggle-menu .toggle-switch:checked {
+  background-image: url("assets/toggle-on.svg") !important;
+}
+
+/* Slider */
+.slider {
+  height: 20px;
+  -barlevel-height: 2px;
+  -barlevel-background-color: rgba(255, 255, 255, 0.3);
+  -barlevel-border-width: 0;
+  -barlevel-border-color: rgba(255, 255, 255, 0.12);
+  -barlevel-active-background-color: #3281EA;
+  -barlevel-active-border-color: #3b87eb;
+  -barlevel-overdrive-color: #F44336;
+  -barlevel-overdrive-border-color: #f54c40;
+  -barlevel-overdrive-separator-width: 2px;
+  -slider-handle-radius: 6px;
+  -slider-handle-border-width: 0;
+  -slider-handle-border-color: white;
+  color: white;
+}
+
+.slider:hover {
+  color: white;
+}
+
+.slider:active {
+  color: #f2f2f2;
+}
+
+/* Scrollbars */
+StScrollView.vfade {
+  -st-vfade-offset: 32px;
+}
+
+StScrollView.hfade {
+  -st-hfade-offset: 32px;
+}
+
+StScrollBar {
+  padding: 0;
+  margin: 6px;
+}
+
+StScrollView StScrollBar {
+  min-width: 8px;
+  min-height: 8px;
+}
+
+StScrollBar StBin#trough {
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+StScrollBar StButton#vhandle, StScrollBar StButton#hhandle {
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 0.5);
+  border: 4px solid transparent;
+  transition: 500ms all ease;
+}
+
+StScrollBar StButton#vhandle:hover, StScrollBar StButton#hhandle:hover {
+  background-color: rgba(255, 255, 255, 0.7);
+}
+
+StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
+  background-color: white;
+}
+
+#LookingGlassDialog StScrollBar StBin#trough, #overviewGroup StScrollBar StBin#trough {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#LookingGlassDialog StScrollBar StButton#vhandle, #overviewGroup StScrollBar StButton#vhandle, #LookingGlassDialog StScrollBar StButton#hhandle, #overviewGroup StScrollBar StButton#hhandle {
+  background-color: rgba(255, 255, 255, 0.5);
+}
+
+#LookingGlassDialog StScrollBar StButton#vhandle:hover, #overviewGroup StScrollBar StButton#vhandle:hover, #LookingGlassDialog StScrollBar StButton#hhandle:hover, #overviewGroup StScrollBar StButton#hhandle:hover {
+  background-color: rgba(255, 255, 255, 0.7);
+}
+
+#LookingGlassDialog StScrollBar StButton#vhandle:active, #overviewGroup StScrollBar StButton#vhandle:active, #LookingGlassDialog StScrollBar StButton#hhandle:active, #overviewGroup StScrollBar StButton#hhandle:active {
+  background-color: white;
+}
+
+.popup-menu .popup-sub-menu StScrollBar StBin#trough {
+  background-color: rgba(0, 0, 0, 0.15);
+}
+
+.popup-menu .popup-sub-menu StScrollBar StButton#vhandle, .popup-menu .popup-sub-menu StScrollBar StButton#hhandle {
+  background-color: rgba(0, 0, 0, 0.35);
+}
+
+.popup-menu .popup-sub-menu StScrollBar StButton#vhandle:hover, .popup-menu .popup-sub-menu StScrollBar StButton#hhandle:hover {
+  background-color: rgba(0, 0, 0, 0.45);
+}
+
+.popup-menu .popup-sub-menu StScrollBar StButton#vhandle:active, .popup-menu .popup-sub-menu StScrollBar StButton#hhandle:active {
+  background-color: rgba(0, 0, 0, 0.65);
+}
+
+/* Popovers/Menus */
+.popup-menu-boxpointer {
+  -arrow-rise: 4px;
+  background: none;
+}
+
+.popup-menu {
+  min-width: 10em;
+  color: white;
+}
+
+.popup-menu .popup-menu-content {
+  padding: 4px;
+  margin: 0 3px 14px;
+  background-color: rgba(33, 33, 33, 0.97);
+  border-radius: 16px;
+  border: none;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+}
+
+.popup-menu .popup-menu-item {
+  spacing: 4px;
+  padding: 4px 8px;
+  color: white !important;
+  background-color: transparent;
+  transition-duration: 100ms;
+  border-radius: 12px;
+  background-image: none;
+  border: none;
+}
+
+.popup-menu .popup-menu-item:checked {
+  font-weight: normal;
+  border-radius: 12px 12px 0 0;
+  border: none;
+  box-shadow: none;
+  background-color: rgba(255, 255, 255, 0.95) !important;
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-menu-item:checked:hover, .popup-menu .popup-menu-item:checked:focus, .popup-menu .popup-menu-item:checked.selected {
+  background-color: #e5e5e5 !important;
+  color: rgba(0, 0, 0, 0.85) !important;
+}
+
+.popup-menu .popup-menu-item:checked:active {
+  background-color: #dfdfdf !important;
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-menu-item:checked.selected:active {
+  background-color: #e0e0e0 !important;
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-menu-item:checked:insensitive {
+  color: rgba(0, 0, 0, 0.35) !important;
+}
+
+.popup-menu .popup-menu-item:hover, .popup-menu .popup-menu-item:focus, .popup-menu .popup-menu-item.selected {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  color: white !important;
+  transition-duration: 0ms;
+}
+
+.popup-menu .popup-menu-item:active {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+  color: white !important;
+  transition-duration: 150ms;
+}
+
+.popup-menu .popup-menu-item.selected:active {
+  color: white !important;
+}
+
+.popup-menu .popup-menu-item:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+}
+
+.popup-menu .popup-menu-item .toggle-switch:ltr {
+  margin-left: 2px;
+}
+
+.popup-menu .popup-menu-item .toggle-switch:rtl {
+  margin-right: 2px;
+}
+
+.popup-menu .popup-ornamented-menu-item:ltr {
+  padding-left: 4px;
+}
+
+.popup-menu .popup-ornamented-menu-item:rtl {
+  padding-right: 4px;
+}
+
+.popup-menu .popup-inactive-menu-item {
+  color: white !important;
+}
+
+.popup-menu .popup-inactive-menu-item:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+}
+
+.popup-menu .popup-menu-arrow,
+.popup-menu .popup-menu-icon {
+  icon-size: 16px;
+}
+
+.popup-menu .popup-sub-menu {
+  margin: 0;
+  border-radius: 0 0 12px 12px;
+  border: none;
+  box-shadow: none;
+  background-image: none;
+  color: rgba(0, 0, 0, 0.75) !important;
+  background-color: rgba(255, 255, 255, 0.95) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item {
+  margin: 0;
+  border-radius: 12px;
+  background-image: none;
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item:hover, .popup-menu .popup-sub-menu .popup-menu-item:focus, .popup-menu .popup-sub-menu .popup-menu-item.selected {
+  color: rgba(0, 0, 0, 0.85) !important;
+  background-color: rgba(0, 0, 0, 0.15) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item:active {
+  color: rgba(0, 0, 0, 0.85) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item.selected:active {
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.35) !important;
+}
+
+.popup-menu .popup-menu-ornament {
+  icon-size: 1.091em !important;
+  width: 1.091em;
+}
+
+.popup-menu .popup-separator-menu-item {
+  background: none;
+  border: none;
+}
+
+.popup-menu .popup-separator-menu-item .popup-separator-menu-item-separator {
+  height: 1px;
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.popup-sub-menu .popup-menu .popup-separator-menu-item {
+  background-color: transparent;
+}
+
+.popup-sub-menu .popup-menu .popup-separator-menu-item:ltr {
+  margin-right: 2.5em;
+  margin-left: 1.5em;
+}
+
+.popup-sub-menu .popup-menu .popup-separator-menu-item:rtl {
+  margin-left: 2.5em;
+  margin-right: 1.5em;
+}
+
+.popup-sub-menu .popup-menu .popup-separator-menu-item .popup-separator-menu-item-separator {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.popup-menu.panel-menu {
+  margin-bottom: 1.75em;
+}
+
+.background-menu {
+  -boxpointer-gap: 0px;
+  -arrow-rise: 0px;
+}
+
+.app-menu {
+  max-width: 27.25em;
+}
+
+.app-menu .popup-inactive-menu-item:first-child > StLabel:ltr {
+  margin-right: 4px;
+}
+
+.app-menu .popup-inactive-menu-item:first-child > StLabel:rtl {
+  margin-left: 4px;
+}
+
+/* Date/Time Menu */
+#calendarArea {
+  padding: 4px 0 !important;
+}
+
+.calendar {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none;
+  box-shadow: none;
+  background: none;
+  text-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.datemenu-calendar-column {
+  spacing: 4px;
+  border: none;
+  padding: 0 !important;
+  margin: 0 !important;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.datemenu-calendar-column:hover, .datemenu-calendar-column:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.datemenu-calendar-column:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.datemenu-calendar-column:ltr {
+  margin-right: 4px !important;
+  margin-left: 10px !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+  border-left-width: 0;
+}
+
+.datemenu-calendar-column:rtl {
+  margin-left: 4px !important;
+  margin-right: 10px !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+  border-right-width: 0;
+}
+
+.datemenu-calendar-column .datemenu-displays-box {
+  spacing: 4px;
+}
+
+.datemenu-today-button {
+  min-height: 40px;
+  padding: 4px;
+  border-radius: 10px;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  background: none;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.datemenu-today-button .day-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+}
+
+.datemenu-today-button .date-label {
+  font-size: 18pt;
+  font-weight: 400;
+}
+
+.datemenu-today-button:hover, .datemenu-today-button:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.datemenu-today-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.calendar-month-label {
+  height: 16px;
+  margin: 2px;
+  padding: 6px 16px;
+  border-radius: 10px;
+  color: rgba(255, 255, 255, 0.7) !important;
+  background-color: transparent !important;
+  font-weight: bold;
+  text-align: center;
+  text-shadow: none;
+}
+
+.calendar-month-label:focus {
+  color: white !important;
+  background-color: rgba(255, 255, 255, 0.08) !important;
+}
+
+.pager-button {
+  width: 24px !important;
+  height: 24px !important;
+  margin: 2px !important;
+  padding: 2px !important;
+  border-radius: 9999px;
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.pager-button:hover, .pager-button:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.08);
+  box-shadow: none !important;
+}
+
+.pager-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.calendar-change-month-back StIcon,
+.calendar-change-month-forward StIcon {
+  icon-size: 16px;
+}
+
+.calendar-change-month-back {
+  padding: 0 2px;
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-change-month-back:rtl {
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward {
+  padding: 0 2px;
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward:rtl {
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-day {
+  font-size: 9pt;
+  font-weight: 400;
+  text-align: center;
+  width: 2.5em !important;
+  height: 2.5em !important;
+  padding: 0 !important;
+  margin: 2px !important;
+  border-radius: 9999px;
+  color: rgba(255, 255, 255, 0.7) !important;
+  border: none !important;
+  font-feature-settings: "tnum";
+  text-shadow: none;
+  background-color: transparent !important;
+}
+
+.calendar-day:hover, .calendar-day:focus {
+  color: white !important;
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  box-shadow: none;
+}
+
+.calendar-day:active {
+  color: white !important;
+  background-color: rgba(255, 255, 255, 0.3) !important;
+  border: none !important;
+}
+
+.calendar-day:selected {
+  color: white !important;
+  background-color: rgba(255, 255, 255, 0.3) !important;
+  border: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.calendar-day.calendar-weekend {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.calendar-day-heading {
+  width: 24px !important;
+  height: 20px !important;
+  margin-top: 2px !important;
+  padding: 4px 0 0 !important;
+  border-radius: 9999px;
+  background-color: transparent !important;
+  color: rgba(255, 255, 255, 0.5) !important;
+  font-size: 9pt;
+  font-weight: 400;
+  font-weight: bold;
+  text-align: center;
+}
+
+.calendar-day {
+  border-width: 0;
+}
+
+.calendar-day-top {
+  border-top-width: 0;
+}
+
+.calendar-day-left {
+  border-left-width: 0;
+}
+
+.calendar-nonwork-day {
+  color: white;
+}
+
+.calendar-today {
+  font-weight: bold !important;
+  color: white !important;
+  background-color: #3281EA !important;
+  border: none;
+}
+
+.calendar-today:hover, .calendar-today:focus {
+  background-color: #408aeb !important;
+  color: white !important;
+}
+
+.calendar-today:active, .calendar-today:selected {
+  background-color: #3281EA !important;
+  color: white !important;
+}
+
+.calendar-today:active:hover, .calendar-today:active:focus, .calendar-today:selected:hover, .calendar-today:selected:focus {
+  background-color: #408aeb !important;
+  color: white !important;
+}
+
+.calendar-day-with-events {
+  color: rgba(255, 255, 255, 0.5);
+  background-image: url("assets/calendar-today.svg");
+  background-size: contain;
+}
+
+.calendar-day-with-events.calendar-work-day {
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: bold;
+}
+
+.calendar-other-month {
+  color: rgba(255, 255, 255, 0.3) !important;
+  font-weight: normal;
+}
+
+.calendar-other-month.calendar-weekend {
+  color: rgba(255, 255, 255, 0.3) !important;
+}
+
+.calendar-week-number {
+  margin: 6px !important;
+  padding: 0 5px !important;
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 0.03);
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 8.25pt;
+  font-weight: bold;
+  text-align: center;
+  text-shadow: none;
+  font-feature-settings: "tnum";
+}
+
+.world-clocks-button,
+.weather-button,
+.events-button,
+.popup-menu .message {
+  padding: 4px 8px;
+  border-radius: 10px;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.world-clocks-button:hover, .world-clocks-button:focus,
+.weather-button:hover,
+.weather-button:focus,
+.events-button:hover,
+.popup-menu .message:hover,
+.events-button:focus,
+.popup-menu .message:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.world-clocks-button:active,
+.weather-button:active,
+.events-button:active,
+.popup-menu .message:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.world-clocks-header,
+.weather-header,
+.message-list-section-title,
+.events-section-title,
+.events-title {
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: bold;
+  margin-bottom: 2px;
+  text-shadow: none;
+}
+
+.weather-grid,
+.world-clocks-grid {
+  spacing-rows: 8px;
+  spacing-columns: 16px;
+}
+
+.world-clocks-header,
+.weather-header,
+.events-section-title {
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: bold;
+  font-size: 0.9em;
+}
+
+.events-button .events-box, .popup-menu .message .events-box {
+  spacing: 6px;
+}
+
+.events-button .events-list, .popup-menu .message .events-list {
+  color: rgba(255, 255, 255, 0.7);
+  spacing: 12px;
+  text-shadow: none;
+}
+
+.events-button .event-time, .popup-menu .message .event-time {
+  color: rgba(255, 255, 255, 0.3);
+  font-feature-settings: "tnum";
+}
+
+.world-clocks-button .world-clocks-city {
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: normal;
+  font-size: 0.9em;
+}
+
+.world-clocks-button .world-clocks-time {
+  color: rgba(255, 255, 255, 0.5);
+  font-feature-settings: "tnum";
+  font-weight: bold;
+  font-size: 0.9em;
+}
+
+.world-clocks-button .world-clocks-time:ltr {
+  text-align: right;
+}
+
+.world-clocks-button .world-clocks-time:rtl {
+  text-align: left;
+}
+
+.world-clocks-button .world-clocks-timezone {
+  color: rgba(255, 255, 255, 0.5);
+  font-feature-settings: "tnum";
+  font-size: 0.9em;
+}
+
+.weather-button .weather-box {
+  spacing: 12px;
+}
+
+.weather-button .weather-header-box {
+  spacing: 8px;
+}
+
+.weather-button .weather-header.location {
+  font-weight: normal;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.8em;
+}
+
+.weather-button .weather-forecast-icon {
+  icon-size: 24px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.weather-button .weather-forecast-time {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.7em;
+  font-feature-settings: "tnum";
+  font-weight: normal;
+  padding-top: 0.2em;
+  padding-bottom: 0.4em;
+}
+
+.weather-button .weather-forecast-temp {
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.65);
+  text-shadow: none;
+}
+
+/* Message List */
+.message-list {
+  width: 29em;
+  color: rgba(255, 255, 255, 0.7);
+  border: solid transparent;
+}
+
+.message-list:ltr {
+  margin-left: 0;
+  margin-right: 0;
+  padding-right: 0;
+  border-right-width: 0;
+}
+
+.message-list:rtl {
+  margin-right: 0;
+  margin-left: 0;
+  padding-left: 0;
+  border-left-width: 0;
+}
+
+.message-list .message-list-placeholder {
+  color: rgba(255, 255, 255, 0.3);
+}
+
+.message-list .message-list-placeholder > StIcon {
+  icon-size: 96px;
+  margin-bottom: 6px;
+  -st-icon-style: symbolic;
+}
+
+.message-list-sections {
+  spacing: 4px;
+}
+
+.message-list-sections:ltr {
+  margin-right: 2px;
+  padding-left: 4px;
+}
+
+.message-list-sections:rtl {
+  margin-left: 2px;
+  padding-right: 4px;
+}
+
+.message-list-section,
+.message-list-section-list {
+  spacing: 4px;
+}
+
+.message-list-controls {
+  margin: 4px 8px 0;
+  padding: 2px;
+  spacing: 8px;
+}
+
+.message-list-controls .dnd-button {
+  border-width: 2px;
+  border-color: transparent;
+  border-radius: 32px;
+  border-style: solid;
+}
+
+.message-list-controls .dnd-button:focus {
+  border-color: rgba(50, 129, 234, 0.6);
+}
+
+.message {
+  border-radius: 10px;
+  padding: 0;
+  margin: 0;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.32);
+  color: white;
+  background-color: rgba(44, 44, 44, 0.96);
+}
+
+.message:hover, .message:focus, .message:active {
+  background-color: #2C2C2C;
+}
+
+.popup-menu .message {
+  border: 1px solid transparent;
+  border-left: none;
+  border-bottom: none;
+  padding: 0;
+  margin: 0;
+  box-shadow: none;
+  margin: 2px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.message:ltr {
+  padding-right: -2px;
+}
+
+.message:rtl {
+  padding-left: -2px;
+}
+
+.message .message-header {
+  padding: 0 0.409em;
+  margin: 4px;
+  margin-bottom: 0;
+  spacing: 4px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.message .message-header .message-source-icon {
+  icon-size: 1.091em;
+  -st-icon-style: symbolic;
+}
+
+.message .message-header .message-header-content {
+  spacing: 4px;
+  min-height: 1.637em;
+  padding-bottom: 4px;
+}
+
+.message .message-header .message-header-content .message-source-title {
+  font-weight: bold;
+}
+
+.message .message-header .message-header-content .event-time {
+  color: rgba(255, 255, 255, 0.5);
+  padding-bottom: 0.068em;
+}
+
+.message .message-header .message-header-content .event-time:ltr {
+  text-align: right;
+}
+
+.message .message-header .message-header-content .event-time:rtl {
+  text-align: left;
+}
+
+.message .message-header .message-expand-button,
+.message .message-header .message-close-button {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.04);
+  padding: 2px;
+}
+
+.message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.message .message-header .message-expand-button:active, .message .message-header .message-expand-button:active:hover,
+.message .message-header .message-close-button:active,
+.message .message-header .message-close-button:active:hover {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive {
+  background-color: transparent;
+}
+
+.message .message-header .message-expand-button {
+  padding: 2px;
+}
+
+.message .message-header .message-expand-button:ltr {
+  margin-right: 4px;
+}
+
+.message .message-header .message-expand-button:rtl {
+  margin-left: 4px;
+}
+
+.message .message-box {
+  padding: 4px;
+  margin: 4px;
+  margin-top: 0;
+  spacing: 4px;
+}
+
+.message .message-box .message-icon {
+  icon-size: 48px;
+  -st-icon-style: symbolic;
+}
+
+.message .message-box .message-icon:ltr {
+  margin-right: 4px;
+}
+
+.message .message-box .message-icon:rtl {
+  margin-left: 4px;
+}
+
+.message .message-box .message-icon.message-themed-icon {
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 0.12);
+  icon-size: 16px;
+  min-width: 48px;
+  min-height: 48px;
+}
+
+.message .message-box:first-child {
+  margin-top: 8px;
+}
+
+.message .message-box .message-content {
+  spacing: 2px;
+}
+
+.message .message-box .message-content .message-title {
+  font-weight: bold;
+}
+
+.url-highlighter {
+  link-color: #3281EA;
+}
+
+/* Media Controls */
+.message-media-control {
+  margin: 8px 2px !important;
+  padding: 0 8px !important;
+  border-radius: 9999px;
+  color: rgba(255, 255, 255, 0.7);
+  border: none;
+}
+
+.message-media-control:hover, .message-media-control:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.message-media-control:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.message-media-control:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+}
+
+.message-media-control StIcon {
+  icon-size: 16px;
+}
+
+.media-message .message-icon {
+  border-radius: 5px !important;
+}
+
+.media-message .message-icon.message-themed-icon {
+  icon-size: 32px !important;
+}
+
+.candidate-popup-boxpointer {
+  -arrow-border-radius: 2px;
+  -arrow-background-color: transparent;
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 64px;
+  -arrow-rise: 12px;
+}
+
+.candidate-popup-content {
+  background-color: #3C3C3C;
+  border-radius: 9px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+  margin: 2px 10px 13px;
+  padding: 4px;
+  spacing: 4px;
+  border: none;
+}
+
+.candidate-index {
+  padding: 0 0.5em 0 0;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.candidate-box:selected .candidate-index {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.candidate-box {
+  padding: 0.3em 0.5em 0.3em 0.5em;
+  margin-right: 2px;
+  border-radius: 5px;
+}
+
+.candidate-box:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+  color: white;
+}
+
+.candidate-box:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: white;
+}
+
+.candidate-box:selected {
+  background-color: #3281EA;
+  color: white;
+}
+
+.candidate-box:last-child {
+  margin-right: 0;
+}
+
+.candidate-page-button-box {
+  height: 2em;
+}
+
+.vertical .candidate-page-button-box {
+  padding-top: 0.5em;
+}
+
+.horizontal .candidate-page-button-box {
+  padding-left: 0.5em;
+}
+
+.candidate-page-button {
+  padding: 4px 8px;
+}
+
+.candidate-page-button-previous {
+  border-radius: 5px;
+  border-right-width: 0;
+}
+
+.candidate-page-button-next {
+  border-radius: 5px;
+  margin-left: 2px;
+}
+
+.candidate-page-button-icon {
+  icon-size: 1em;
+}
+
+.quick-settings {
+  padding: 12px !important;
+  border-radius: 28px !important;
+  margin-top: 2px !important;
+  border: none;
+}
+
+.quick-settings .icon-button, .quick-settings .background-app-item .close-button, .background-app-item .quick-settings .close-button, .quick-settings .message .message-header .message-expand-button, .message .message-header .quick-settings .message-expand-button,
+.quick-settings .message .message-header .message-close-button,
+.message .message-header .quick-settings .message-close-button, .quick-settings .button {
+  padding: 8px;
+}
+
+.quick-settings .icon-button > StIcon, .quick-settings .background-app-item .close-button > StIcon, .background-app-item .quick-settings .close-button > StIcon, .quick-settings .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings .message-expand-button > StIcon,
+.quick-settings .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings .message-close-button > StIcon, .quick-settings .button > StIcon {
+  icon-size: 16px;
+}
+
+.quick-settings-grid {
+  spacing-rows: 8px;
+  spacing-columns: 8px;
+}
+
+.quick-toggle, .quick-menu-toggle {
+  border-radius: 9999px;
+  min-width: 10.5em;
+  max-width: 10.5em;
+  min-height: 34px;
+  border: none;
+}
+
+.quick-toggle {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+  /* Move padding into the box; this is to allow menu arrows
+     to extend to the border */
+}
+
+.quick-toggle:hover {
+  background-color: rgba(255, 255, 255, 0.12) !important;
+}
+
+.quick-toggle:active {
+  background-color: rgba(255, 255, 255, 0.24) !important;
+}
+
+.quick-toggle:checked {
+  background-color: #3281EA !important;
+  color: white !important;
+}
+
+.quick-toggle:checked:hover {
+  background-color: #478eec !important;
+  color: white !important;
+}
+
+.quick-toggle:checked:active {
+  background-color: #5b9aee !important;
+  color: white !important;
+}
+
+.quick-toggle > StBoxLayout {
+  spacing: 4px;
+}
+
+.quick-toggle.button {
+  padding: 0;
+}
+
+.quick-toggle > StBoxLayout {
+  padding: 0 8px;
+}
+
+.quick-toggle:ltr > StBoxLayout {
+  padding-left: 10px;
+}
+
+.quick-toggle:rtl > StBoxLayout {
+  padding-right: 10px;
+}
+
+.quick-toggle .quick-toggle-title {
+  font-weight: bold;
+}
+
+.quick-toggle StBoxLayout > .quick-toggle-subtitle {
+  font-weight: normal;
+  font-size: 12px;
+}
+
+.quick-toggle .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-menu-toggle .quick-toggle {
+  min-width: auto;
+  max-width: auto;
+}
+
+.quick-menu-toggle .quick-toggle:ltr {
+  border-radius: 9999px 0 0 9999px;
+}
+
+.quick-menu-toggle .quick-toggle:ltr > StBoxLayout {
+  padding-right: 0;
+}
+
+.quick-menu-toggle .quick-toggle:rtl {
+  border-radius: 0 9999px 9999px 0;
+}
+
+.quick-menu-toggle .quick-toggle:rtr > StBoxLayout {
+  padding-left: 0;
+}
+
+.quick-menu-toggle .quick-toggle:ltr:last-child {
+  border-radius: 9999px;
+}
+
+.quick-menu-toggle .quick-toggle:rtl:last-child {
+  border-radius: 9999px;
+}
+
+.quick-menu-toggle .quick-toggle-arrow {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  padding: 4px 7px;
+  border: none !important;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:hover {
+  background-color: rgba(255, 255, 255, 0.12) !important;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:active {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:checked {
+  background-color: #3281EA !important;
+  color: white;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:checked:hover {
+  background-color: #478eec !important;
+  color: white;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:checked:active {
+  background-color: #5b9aee !important;
+  color: white;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:ltr {
+  border-radius: 0 9999px 9999px 0;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:rtl {
+  border-radius: 9999px 0 0 9999px;
+}
+
+.quick-slider > StBoxLayout {
+  spacing: 4px;
+}
+
+.quick-slider .icon-button, .quick-slider .background-app-item .close-button, .background-app-item .quick-slider .close-button, .quick-slider .message .message-header .message-expand-button, .message .message-header .quick-slider .message-expand-button,
+.quick-slider .message .message-header .message-close-button,
+.message .message-header .quick-slider .message-close-button {
+  padding: 6px;
+}
+
+.quick-slider .slider-bin {
+  min-height: 16px;
+  padding: 4px;
+  border-radius: 9999px;
+}
+
+.quick-slider .slider-bin:focus {
+  color: #3281EA;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.quick-slider .slider-bin:focus:active {
+  color: white;
+}
+
+.quick-slider .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-toggle-menu {
+  border-radius: 20px !important;
+  padding: 8px;
+  margin: 8px 14px 0;
+  background-color: white !important;
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+.quick-toggle-menu:insensitive {
+  background-color: white !important;
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+.quick-toggle-menu .popup-menu-item {
+  padding: 6px !important;
+  border-radius: 9999px !important;
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+.quick-toggle-menu .popup-menu-item StLabel {
+  color: rgba(0, 0, 0, 0.65);
+}
+
+.quick-toggle-menu .popup-menu-item:focus, .quick-toggle-menu .popup-menu-item:hover, .quick-toggle-menu .popup-menu-item.selected {
+  color: rgba(0, 0, 0, 0.75) !important;
+  background-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.quick-toggle-menu .popup-menu-item:active {
+  color: rgba(0, 0, 0, 0.75) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+
+.quick-toggle-menu .popup-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.25) !important;
+}
+
+.quick-toggle-menu .popup-menu-item > StIcon {
+  -st-icon-style: symbolic;
+  icon-size: 1.091em;
+}
+
+.quick-toggle-menu .popup-menu-item > :first-child:ltr {
+  padding-left: 6px !important;
+}
+
+.quick-toggle-menu .popup-menu-item > :first-child:rtl {
+  padding-right: 6px !important;
+}
+
+.quick-toggle-menu .popup-menu-item .popup-separator-menu-item-separator {
+  margin: 4px 12px 4px 0 !important;
+  padding: 0 !important;
+  background-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.quick-toggle-menu .popup-menu-item .toggle-switch {
+  background-image: url("assets/menu-toggle-off.svg");
+}
+
+.quick-toggle-menu .header {
+  spacing-rows: 2px;
+  spacing-columns: 8px;
+  padding-bottom: 8px;
+}
+
+.quick-toggle-menu .header .icon {
+  icon-size: 24px;
+  border-radius: 9999px;
+  padding: 6px;
+  background-color: rgba(0, 0, 0, 0.08) !important;
+}
+
+.quick-toggle-menu .header .icon.active {
+  background-color: #3281EA !important;
+  color: white !important;
+}
+
+.quick-settings-system-item > StBoxLayout {
+  spacing: 8px;
+}
+
+.quick-settings-system-item .icon-button, .quick-settings-system-item .background-app-item .close-button, .background-app-item .quick-settings-system-item .close-button, .quick-settings-system-item .message .message-header .message-expand-button, .message .message-header .quick-settings-system-item .message-expand-button,
+.quick-settings-system-item .message .message-header .message-close-button,
+.message .message-header .quick-settings-system-item .message-close-button {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.quick-settings-system-item .icon-button:hover, .quick-settings-system-item .background-app-item .close-button:hover, .background-app-item .quick-settings-system-item .close-button:hover, .quick-settings-system-item .message .message-header .message-expand-button:hover, .message .message-header .quick-settings-system-item .message-expand-button:hover,
+.quick-settings-system-item .message .message-header .message-close-button:hover,
+.message .message-header .quick-settings-system-item .message-close-button:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.quick-settings-system-item .icon-button:active, .quick-settings-system-item .background-app-item .close-button:active, .background-app-item .quick-settings-system-item .close-button:active, .quick-settings-system-item .message .message-header .message-expand-button:active, .message .message-header .quick-settings-system-item .message-expand-button:active,
+.quick-settings-system-item .message .message-header .message-close-button:active,
+.message .message-header .quick-settings-system-item .message-close-button:active {
+  background-color: rgba(255, 255, 255, 0.24);
+}
+
+.quick-settings-system-item .icon-button > StIcon, .quick-settings-system-item .background-app-item .close-button > StIcon, .background-app-item .quick-settings-system-item .close-button > StIcon, .quick-settings-system-item .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings-system-item .message-expand-button > StIcon,
+.quick-settings-system-item .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings-system-item .message-close-button > StIcon {
+  -st-icon-style: symbolic;
+}
+
+.quick-settings-system-item .power-item {
+  min-height: 0;
+  min-width: 0;
+}
+
+.quick-settings-system-item .power-item:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.04);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+  background-color: transparent;
+}
+
+.nm-network-item .wireless-secure-icon {
+  icon-size: 8px;
+}
+
+.bt-device-item .popup-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  text-align: center;
+  padding: 2em 4em;
+}
+
+.device-subtitle {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.keyboard-brightness-level {
+  spacing: 4px;
+  background-color: #3C3C3C !important;
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+.background-apps-quick-toggle {
+  min-height: 34px;
+  background-color: transparent;
+}
+
+.background-apps-quick-toggle StIcon {
+  icon-size: 16px !important;
+}
+
+.background-app-item .popup-menu-icon {
+  icon-size: 32px !important;
+  -st-icon-style: regular !important;
+}
+
+.background-app-item .close-button {
+  padding: 4px;
+}
+
+.background-app-item.popup-inactive-menu-item {
+  color: white;
+}
+
+/* Notifications & Message Tray */
+.notification-banner {
+  min-height: 64px;
+  width: 34em;
+  font-size: 1em;
+  margin: 4px;
+  border-radius: 16px;
+  border-left: none;
+  border-bottom: none;
+}
+
+.notification-buttons-bin {
+  background-color: transparent;
+  padding: 0;
+  spacing: 0;
+  margin: 0;
+}
+
+.notification-button {
+  min-height: 40px;
+  padding: 2px 16px;
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.7);
+  font-weight: 500;
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.popup-menu .notification-button {
+  padding: 0 16px;
+}
+
+.notification-button:first-child:ltr {
+  border-radius: 0 0 0 16px;
+}
+
+.notification-button:last-child:ltr {
+  border-radius: 0 0 16px;
+  margin-right: 0 !important;
+}
+
+.notification-button:first-child:rtl {
+  border-radius: 0 0 16px;
+}
+
+.notification-button:last-child:rtl {
+  border-radius: 0 0 0 16px;
+  margin-left: 0 !important;
+}
+
+.notification-button:first-child:last-child {
+  border-radius: 0 0 16px 16px;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.notification-button:focus {
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.7);
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.08);
+}
+
+.notification-button:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+  color: white;
+  box-shadow: none;
+}
+
+.notification-button:active, .notification-button:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: white;
+}
+
+.notification-button:insensitive {
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.3);
+}
+
+.popup-menu .notification-button:first-child:ltr {
+  border-radius: 0 0 0 10px;
+}
+
+.popup-menu .notification-button:last-child:ltr {
+  border-radius: 0 0 10px;
+}
+
+.popup-menu .notification-button:first-child:rtl {
+  border-radius: 0 0 10px;
+}
+
+.popup-menu .notification-button:last-child:rtl {
+  border-radius: 0 0 0 10px;
+}
+
+.popup-menu .notification-button:first-child:last-child {
+  border-radius: 0 0 10px 10px;
+}
+
+.hotplug-notification-item {
+  padding: 2px 10px;
+}
+
+.hotplug-notification-item-icon {
+  icon-size: 24px;
+  padding: 0 4px;
+}
+
+/* Modal Dialogs */
+.headline {
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.modal-dialog {
+  border-radius: 24px;
+  color: white;
+  background-color: #2C2C2C;
+  border: 0 none rgba(0, 0, 0, 0.75);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+}
+
+.modal-dialog .modal-dialog-content-box {
+  margin: 32px 40px;
+  spacing: 32px;
+  max-width: 28em;
+  background-color: #2C2C2C;
+}
+
+.modal-dialog .modal-dialog-linked-button {
+  min-height: 40px;
+  padding: 0 16px;
+}
+
+/* End Session Dialog */
+.end-session-dialog {
+  width: 30em;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child {
+  color: white !important;
+  background-color: #F44336;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:hover {
+  color: white !important;
+  background-color: #f66c62;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:active {
+  color: white !important;
+  background-color: #f32c1e;
+}
+
+.end-session-dialog .end-session-dialog-battery-warning,
+.end-session-dialog .dialog-list-title {
+  color: #FBC02D;
+}
+
+/* Message Dialog */
+.message-dialog-content {
+  spacing: 18px;
+}
+
+.message-dialog-content .message-dialog-title {
+  text-align: center;
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-title.lightweight {
+  font-size: 13pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-description {
+  text-align: center;
+}
+
+/* Dialog List */
+.dialog-list {
+  spacing: 18px;
+}
+
+.dialog-list .dialog-list-title {
+  text-align: center;
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-scrollview {
+  max-height: 200px;
+}
+
+.dialog-list .dialog-list-box {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-title {
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-description {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+/* Run Dialog */
+.run-dialog .modal-dialog-content-box {
+  margin-top: 24px;
+  margin-bottom: 14px;
+}
+
+.run-dialog .run-dialog-entry {
+  width: 20em;
+}
+
+.run-dialog .run-dialog-description {
+  font-size: 11.25pt;
+  font-weight: 400;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Password or Authentication Dialog */
+.prompt-dialog {
+  width: 28em;
+}
+
+.prompt-dialog .modal-dialog-linked-button:first-child {
+  color: #F44336;
+}
+
+.prompt-dialog .modal-dialog-linked-button:first-child:active {
+  color: white !important;
+  background-color: #F44336;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child {
+  color: white !important;
+  background-color: #3281EA;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:hover {
+  color: white !important;
+  background-color: #5c9bee;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:active {
+  color: white !important;
+  background-color: #1b73e8;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:insensitive {
+  color: rgba(50, 129, 234, 0.5) !important;
+  background-color: rgba(50, 129, 234, 0.15);
+}
+
+.prompt-dialog .modal-dialog-content-box {
+  margin-bottom: 24px;
+  background-color: #2C2C2C;
+}
+
+.prompt-dialog-password-grid {
+  spacing-rows: 8px;
+  spacing-columns: 4px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry {
+  width: auto;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:ltr {
+  margin-left: 20px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:rtl {
+  margin-right: 20px;
+}
+
+.prompt-dialog-password-layout {
+  spacing: 8px;
+}
+
+.prompt-dialog-password-entry {
+  width: 20em;
+}
+
+.prompt-dialog-error-label,
+.prompt-dialog-info-label,
+.prompt-dialog-null-label {
+  text-align: center;
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.prompt-dialog-error-label {
+  color: #FBC02D;
+}
+
+/* Polkit Dialog */
+.polkit-dialog-user-layout {
+  text-align: center;
+  spacing: 8px;
+  margin-bottom: 6px;
+}
+
+.polkit-dialog-user-layout .polkit-dialog-user-root-label {
+  color: #FBC02D;
+}
+
+/* Audio selection dialog */
+.audio-device-selection-dialog .modal-dialog-content-box {
+  margin-bottom: 28px;
+}
+
+.audio-device-selection-dialog .audio-selection-box {
+  spacing: 20px;
+}
+
+.audio-selection-device {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+}
+
+.audio-selection-device:active, .audio-selection-device:hover, .audio-selection-device:focus {
+  background-color: #3281EA;
+}
+
+.audio-selection-device-box {
+  padding: 20px;
+  spacing: 20px;
+}
+
+.audio-selection-device-icon {
+  icon-size: 64px;
+}
+
+/* Welcome dialog */
+.welcome-dialog-image {
+  background-image: url("resource:///org/gnome/shell/theme/gnome-shell-start.svg");
+  background-size: contain;
+  /* Reasonable maximum dimensions */
+  height: 300px;
+  width: 300px;
+}
+
+/* Network Dialogs */
+.nm-dialog {
+  max-height: 34em;
+  min-height: 31em;
+  min-width: 32em;
+}
+
+.nm-dialog-content {
+  spacing: 20px;
+  padding: 24px;
+}
+
+.nm-dialog-airplane-box {
+  spacing: 12px;
+}
+
+.nm-dialog-airplane-headline {
+  font-weight: bold;
+  text-align: center;
+}
+
+.nm-dialog-airplane-text {
+  color: white;
+}
+
+.nm-dialog-header {
+  font-weight: bold;
+}
+
+.nm-dialog-header-icon {
+  icon-size: 32px;
+}
+
+.nm-dialog-header-hbox {
+  spacing: 10px;
+}
+
+.nm-dialog-scroll-view {
+  border: none;
+  background-color: rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 8px;
+  padding-right: 0;
+}
+
+.nm-dialog-item {
+  font-size: 1em;
+  border-bottom: none;
+  border-radius: 6px;
+  padding: 8px;
+  spacing: 0px;
+}
+
+.nm-dialog-item:hover, .nm-dialog-item:focus {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.nm-dialog-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.nm-dialog-item:selected {
+  background-color: #3281EA;
+  color: white;
+}
+
+.nm-dialog-icon {
+  icon-size: 16px;
+}
+
+.nm-dialog-icons {
+  spacing: 8px;
+}
+
+.no-networks-label {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.no-networks-box {
+  spacing: 4px;
+}
+
+/* OSD */
+.osd-window {
+  text-align: center;
+  font-weight: bold;
+  spacing: 8px;
+  padding: 8px 12px;
+  margin-bottom: 8em;
+  border-radius: 9999px;
+}
+
+.osd-window > * {
+  spacing: 8px;
+}
+
+.osd-window StIcon {
+  icon-size: 32px;
+}
+
+.osd-window .osd-monitor-label {
+  font-size: 3em;
+}
+
+.osd-window StLabel:ltr {
+  margin-right: 4px;
+}
+
+.osd-window StLabel:rtl {
+  margin-left: 4px;
+}
+
+.osd-window .level {
+  height: 4px;
+  min-width: 160px;
+  margin-bottom: 4px;
+  -barlevel-height: 4px;
+  -barlevel-background-color: rgba(50, 129, 234, 0.3);
+  -barlevel-active-background-color: #3281EA;
+  -barlevel-overdrive-color: #F44336;
+  -barlevel-overdrive-separator-width: 3px;
+  -barlevel-border-width: 0;
+}
+
+.osd-window .level:first-child {
+  margin-bottom: 0px;
+}
+
+.osd-window .level:ltr {
+  margin-right: 4px;
+}
+
+.osd-window .level:rtl {
+  margin-left: 4px;
+}
+
+.osd-monitor-label {
+  border-radius: 16px;
+  font-size: 3em;
+  font-weight: bold;
+  margin: 6px;
+  text-align: center;
+  min-width: 1.3em;
+}
+
+/* Pad OSD */
+.pad-osd-window {
+  padding: 32px;
+  background-color: rgba(0, 0, 0, 0.8);
+  border: none;
+}
+
+.pad-osd-window .pad-osd-title-box {
+  spacing: 8px;
+}
+
+.pad-osd-window .pad-osd-title-menu-box {
+  spacing: 4px;
+}
+
+.combo-box-label {
+  width: 15em;
+}
+
+.resize-popup {
+  border-radius: 16px;
+}
+
+/* App Switcher */
+.switcher-popup {
+  padding: 8px;
+  spacing: 16px;
+}
+
+.switcher-list {
+  border-radius: 18px;
+}
+
+.switcher-list .item-box {
+  padding: 8px;
+  border-radius: 10px;
+  border: none;
+  background-color: transparent;
+  color: white;
+}
+
+.switcher-list .item-box:outlined {
+  background-color: rgba(255, 255, 255, 0.08);
+  color: white;
+}
+
+.switcher-list .item-box:selected {
+  background-color: #3281EA;
+  color: white;
+}
+
+.switcher-list .thumbnail-box {
+  padding: 2px;
+  spacing: 4px;
+}
+
+.switcher-list .thumbnail {
+  width: 256px;
+}
+
+.switcher-list .separator {
+  width: 1px;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.switcher-list .switcher-list-item-container {
+  spacing: 8px;
+}
+
+.switcher-arrow {
+  border-color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.switcher-arrow:highlighted {
+  color: white;
+}
+
+.input-source-switcher-symbol {
+  font-size: 34pt;
+  width: 96px;
+  height: 96px;
+}
+
+.cycler-highlight {
+  border: 5px solid #3281EA;
+}
+
+/* Workspace Switcher */
+.workspace-switcher-group {
+  padding: 8px;
+}
+
+.workspace-switcher-container {
+  border-radius: 16px;
+}
+
+.workspace-switcher {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  spacing: 8px;
+}
+
+.ws-switcher-box {
+  height: 50px;
+  background-size: 32px;
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+}
+
+.ws-switcher-active-up,
+.ws-switcher-active-down,
+.ws-switcher-active-left,
+.ws-switcher-active-right {
+  height: 52px;
+  background-color: #3281EA;
+  border: none;
+  border-radius: 12px;
+  color: white;
+}
+
+/* Top Bar */
+#panel {
+  font-weight: bold;
+  font-feature-settings: "tnum";
+  padding: 0 !important;
+  transition-duration: 250ms;
+  height: 34px;
+  border: none;
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.65);
+  margin: 2px;
+  border-radius: 9999px;
+}
+
+#panel.unlock-screen, #panel.login-screen, #panel:overview {
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-corner, #panel.login-screen .panel-corner, #panel:overview .panel-corner {
+  -panel-corner-opacity: 0;
+}
+
+#panel .panel-corner {
+  -panel-corner-radius: 0;
+  -panel-corner-background-color: rgba(33, 33, 33, 0.65);
+  -panel-corner-border-width: 0;
+  -panel-corner-border-color: transparent;
+  -panel-corner-opacity: 1;
+  transition-duration: 250ms;
+}
+
+#panel .panel-button#panelActivities {
+  -natural-hpadding: 10px;
+}
+
+#panel .panel-button#panelActivities StBoxLayout {
+  spacing: 4px;
+}
+
+#panel .panel-button#panelActivities .workspace-dot {
+  border-radius: 9999px;
+  min-width: 8px;
+  min-height: 8px;
+  background-color: white;
+}
+
+#panel .panel-button {
+  font-weight: bold;
+  color: white;
+  -natural-hpadding: 9px;
+  -minimum-hpadding: 9px;
+  transition-duration: 150ms;
+  border: 2px solid transparent;
+  border-radius: 9999px;
+  margin: 0;
+}
+
+#panel .panel-button.clock-display {
+  -natural-hpadding: 0 !important;
+  -minimum-hpadding: 0 !important;
+  padding: 0 !important;
+  spacing: 0 !important;
+}
+
+#panel .panel-button.clock-display .clock-display-box {
+  spacing: 0;
+}
+
+#panel .panel-button.clock-display .clock {
+  border-radius: 9999px;
+  padding: 0 8px !important;
+}
+
+#panel .panel-button:hover {
+  background-color: transparent;
+  box-shadow: inset 0 0 0 1000px rgba(255, 255, 255, 0.12);
+}
+
+#panel .panel-button:hover.clock-display {
+  box-shadow: none;
+  background-color: transparent;
+}
+
+#panel .panel-button:hover.clock-display .clock {
+  box-shadow: inset 0 0 0 1000px rgba(255, 255, 255, 0.12);
+}
+
+#panel .panel-button:active, #panel .panel-button:overview, #panel .panel-button:focus, #panel .panel-button:checked {
+  background-color: transparent;
+  box-shadow: inset 0 0 0 1000px rgba(255, 255, 255, 0.3);
+}
+
+#panel .panel-button:active.clock-display, #panel .panel-button:overview.clock-display, #panel .panel-button:focus.clock-display, #panel .panel-button:checked.clock-display {
+  box-shadow: none;
+  background-color: transparent;
+}
+
+#panel .panel-button:active.clock-display .clock, #panel .panel-button:overview.clock-display .clock, #panel .panel-button:focus.clock-display .clock, #panel .panel-button:checked.clock-display .clock {
+  box-shadow: inset 0 0 0 1000px rgba(255, 255, 255, 0.3);
+}
+
+#panel .panel-button .system-status-icon {
+  icon-size: 16px;
+  padding: 4px;
+  margin: 0;
+}
+
+#panel .panel-button .appindicator-trayicons-box {
+  margin: 0 4px;
+}
+
+#panel .panel-button .app-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button {
+  border: 0 none transparent !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  -natural-hpadding: 2px !important;
+  -minimum-hpadding: 2px !important;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .panel-status-menu-box,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .panel-status-menu-box,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .panel-status-menu-box {
+  spacing: 0;
+  padding: 0;
+  margin: 0;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon {
+  border-radius: 9999px;
+  width: 31px;
+  margin: 2px 0;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:hover,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  box-shadow: none;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:active, #panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:overview, #panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:focus, #panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:checked,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:active,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:overview,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:focus,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: none;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button {
+  border-radius: 9999px;
+  width: 31px;
+  margin: 2px 0;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  box-shadow: none;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:active, #panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:overview, #panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:focus, #panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: none;
+}
+
+#panel Gjs_status_keyboard_InputSourceIndicator.panel-button,
+#panel Gjs_appindicatorsupport_rgcjonas_gmail_com_indicatorStatusIcon_IndicatorStatusIcon.panel-button,
+#panel Gjs_appindicatorsupport_rgcjonas_gmail_com_indicatorStatusIcon_AppIndicatorsIndicatorStatusIcon.panel-button {
+  -natural-hpadding: 13px !important;
+  -minimum-hpadding: 13px !important;
+}
+
+#panel .screencast-indicator,
+#panel .remote-access-indicator {
+  color: #FBC02D;
+}
+
+#appMenu {
+  spacing: 4px;
+}
+
+#appMenu .label-shadow {
+  color: transparent;
+}
+
+#appMenu .panel-status-menu-box {
+  padding: 0 4px;
+  spacing: 4px;
+}
+
+/* Activities Ripple */
+.ripple-box {
+  background-color: rgba(50, 129, 234, 0.35);
+  width: 52px;
+  height: 52px;
+  border-radius: 0 0 52px 0;
+}
+
+.ripple-box:rtl {
+  border-radius: 0 0 0 52px;
+}
+
+/* OVERVIEW */
+.controls-manager, .secondary-monitor-workspaces {
+  spacing: 8px;
+}
+
+#overviewGroup {
+  background-color: #242424;
+}
+
+.overview-controls {
+  padding-bottom: 32px;
+}
+
+/* Window Picker */
+.window-picker {
+  spacing: 4px;
+}
+
+.window-caption {
+  color: white;
+  background-color: rgba(25, 25, 25, 0.9);
+  border-radius: 9999px;
+  padding: 4px 8px;
+  box-shadow: none;
+  border: none;
+}
+
+.window-close, .screenshot-ui-close-button {
+  background-color: #242424;
+  color: white;
+  border-radius: 9999px;
+  padding: 3px;
+  height: 30px;
+  width: 30px;
+  box-shadow: -1px 1px 5px 0px rgba(0, 0, 0, 0.5);
+  transition-duration: 300ms;
+}
+
+.window-close StIcon, .screenshot-ui-close-button StIcon {
+  icon-size: 24px;
+}
+
+.window-close:hover, .screenshot-ui-close-button:hover {
+  background-color: #4a4a4a;
+}
+
+.window-close:active, .screenshot-ui-close-button:active {
+  color: rgba(255, 255, 255, 0.8);
+  background-color: #171717;
+}
+
+.workspace-background {
+  border-radius: 30px;
+  background-color: #242424;
+  box-shadow: 0 4px 16px 4px rgba(0, 0, 0, 0.15);
+}
+
+.search-entry {
+  min-height: 24px;
+  padding: 4px 4px;
+  width: 320px;
+  border-radius: 9999px;
+  selection-background-color: #3281EA;
+  selected-color: white !important;
+  caret-color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.12);
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.search-entry:hover {
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.12) !important;
+}
+
+.search-entry:focus {
+  color: white;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #3281EA !important;
+}
+
+.search-entry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.search-entry .search-entry-icon {
+  icon-size: 16px;
+  padding: 0 4px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.search-entry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+#overview .search-entry {
+  margin-top: 8px;
+  margin-bottom: 4px;
+  border: none !important;
+  caret-color: rgba(0, 0, 0, 0.75);
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.75);
+  border-color: transparent !important;
+  box-shadow: none !important;
+}
+
+#overview .search-entry:hover {
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.85);
+  box-shadow: none !important;
+}
+
+#overview .search-entry:focus {
+  color: rgba(0, 0, 0, 0.85);
+  border-color: transparent;
+  background-color: rgba(255, 255, 255, 0.95);
+  border: none !important;
+  box-shadow: none !important;
+  selection-background-color: #3281EA;
+  selected-color: white !important;
+}
+
+#overview .search-entry .search-entry-icon {
+  color: rgba(0, 0, 0, 0.65);
+}
+
+#overview .search-entry:hover .search-entry-icon, #overview .search-entry:focus .search-entry-icon {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+#overview .search-entry StLabel.hint-text {
+  color: rgba(0, 0, 0, 0.35);
+}
+
+/* Search */
+#searchResults {
+  margin: 0 2px;
+}
+
+#searchResultsContent {
+  max-width: 1044px;
+}
+
+.search-section {
+  spacing: 6px;
+}
+
+.search-section .search-section-separator {
+  height: 4px;
+  background-color: transparent;
+}
+
+.search-section-content {
+  background-color: rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  color: white;
+  padding: 8px;
+  margin: 0 6px;
+}
+
+.list-search-result, .search-provider-icon {
+  border-radius: 10px;
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.list-search-result:focus, .search-provider-icon:focus, .list-search-result:hover, .search-provider-icon:hover, .list-search-result:selected, .search-provider-icon:selected {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  transition-duration: 200ms;
+  border-radius: 10px;
+}
+
+.list-search-result:active, .search-provider-icon:active, .list-search-result:checked, .search-provider-icon:checked {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-radius: 10px;
+}
+
+.search-statustext {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.grid-search-results {
+  spacing: 20px;
+  margin: 0 6px;
+}
+
+.search-provider-icon:ltr {
+  margin-right: 2px;
+}
+
+.search-provider-icon:rtl {
+  margin-left: 2px;
+}
+
+.search-provider-icon .list-search-provider-content {
+  spacing: 8px;
+}
+
+.search-provider-icon .list-search-provider-content .list-search-provider-details {
+  width: 120px;
+  margin-top: 0;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.list-search-results {
+  spacing: 4px;
+}
+
+.list-search-result .list-search-result-content {
+  spacing: 4px;
+}
+
+.list-search-result .list-search-result-title {
+  spacing: 8px;
+}
+
+.list-search-result .list-search-result-description {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Dash */
+#dash {
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+#dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 9999px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+#dash .dash-item-container .placeholder {
+  background-image: none;
+  background-size: contain;
+  height: 32px;
+}
+
+#dash .dash-item-container .empty-dash-drop-target {
+  width: 32px;
+  height: 32px;
+}
+
+#dash .dash-item-container .show-apps,
+#dash .dash-item-container .overview-tile,
+#dash .dash-item-container .grid-search-result {
+  background: none;
+  box-shadow: none;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  margin: 0 2px;
+  padding-bottom: 12px;
+}
+
+#dash .dash-item-container .show-apps .overview-icon,
+#dash .dash-item-container .overview-tile .overview-icon,
+#dash .dash-item-container .grid-search-result .overview-icon {
+  border-radius: 9999px;
+  padding: 4px;
+  spacing: 4px;
+  text-align: center;
+  transition-duration: 100ms;
+  background-color: transparent;
+  color: white;
+}
+
+#dash .dash-item-container .show-apps:focus .overview-icon,
+#dash .dash-item-container .overview-tile:focus .overview-icon,
+#dash .dash-item-container .grid-search-result:focus .overview-icon {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#dash .dash-item-container .show-apps:hover .overview-icon,
+#dash .dash-item-container .overview-tile:hover .overview-icon,
+#dash .dash-item-container .grid-search-result:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#dash .dash-item-container .show-apps:active .overview-icon,
+#dash .dash-item-container .overview-tile:active .overview-icon,
+#dash .dash-item-container .grid-search-result:active .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#dash .dash-item-container .show-apps:checked .overview-icon,
+#dash .dash-item-container .overview-tile:checked .overview-icon,
+#dash .dash-item-container .grid-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#dash .dash-item-container .app-grid-running-dot {
+  offset-y: -12px;
+}
+
+#dash .dash-separator {
+  width: 1px;
+  margin-left: 2px;
+  margin-right: 2px;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-separator,
+#dash .dash-background {
+  margin-bottom: 12px;
+}
+
+.dash-label {
+  border-radius: 9999px;
+  padding: 4px 8px;
+  margin: 6px;
+  color: white;
+  background-color: rgba(0, 0, 0, 0.75);
+  border: none;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.32);
+  text-align: center;
+  -y-offset: 0;
+  -x-offset: 0;
+}
+
+/* App Grid */
+.icon-grid {
+  row-spacing: 12px;
+  column-spacing: 12px;
+  max-row-spacing: 36px;
+  max-column-spacing: 36px;
+  page-padding-top: 24px;
+  page-padding-bottom: 24px;
+  page-padding-left: 18px;
+  page-padding-right: 18px;
+}
+
+/* App Icons */
+.overview-tile, .grid-search-result {
+  border-radius: 20px;
+  padding: 12px;
+  spacing: 6px;
+  transition-duration: 150ms;
+  text-align: center;
+  background-color: transparent;
+  color: white;
+  border: 1px solid transparent;
+  box-shadow: inset 0 1px transparent;
+}
+
+.overview-tile:hover, .grid-search-result:hover, .overview-tile:focus, .grid-search-result:focus, .overview-tile:highlighted, .grid-search-result:highlighted, .overview-tile:selected, .grid-search-result:selected {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+  transition-duration: 0ms;
+  border-image: none;
+  background-image: none;
+}
+
+.overview-tile:active, .grid-search-result:active, .overview-tile:checked, .grid-search-result:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+  transition-duration: 150ms;
+  color: white;
+}
+
+.overview-tile .overview-icon.overview-icon-with-label > StBoxLayout, .grid-search-result .overview-icon.overview-icon-with-label > StBoxLayout {
+  spacing: 6px;
+}
+
+.notification-badge {
+  min-width: 16px;
+  min-height: 16px;
+  color: white;
+  background-color: #3281EA;
+  border-radius: 9999px;
+  padding: 0.2em 0.4em;
+  text-align: center;
+}
+
+.app-folder {
+  background-color: rgba(255, 255, 255, 0.04);
+  border-radius: 20px;
+}
+
+.app-folder:focus, .app-folder:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.app-folder:active, .app-folder:highlighted, .app-folder:selected, .app-folder:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder:insensitive {
+  background-color: transparent;
+}
+
+.app-grid-running-dot {
+  width: 6px;
+  height: 3px;
+  border-radius: 2px;
+  background-color: rgba(255, 255, 255, 0.3);
+  margin-bottom: 1px;
+}
+
+StWidget.focused .app-grid-running-dot {
+  width: 18px;
+  background-color: #3281EA;
+}
+
+.app-folder-dialog-container {
+  padding-top: 34px;
+}
+
+.app-folder-dialog {
+  border-radius: 40px;
+  border: none;
+  background-color: rgba(36, 36, 36, 0.95);
+  color: white;
+  spacing: 6px;
+  box-shadow: none;
+  outline: none;
+}
+
+.app-folder-dialog .folder-name-container {
+  padding: 24px 36px 0;
+  spacing: 12px;
+  /* FIXME: this is to keep the label in sync with the entry */
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label,
+.app-folder-dialog .folder-name-container .folder-name-entry {
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry {
+  min-height: 28px;
+  padding: 4px;
+  border: none;
+  color: white;
+  background-color: rgba(255, 255, 255, 0.15);
+  caret-color: white;
+  selection-background-color: rgba(255, 255, 255, 0.12) !important;
+  selected-color: white !important;
+  width: 300px;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:hover .search-entry-icon, .app-folder-dialog .folder-name-container .folder-name-entry:focus .search-entry-icon {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:insensitive, .app-folder-dialog .folder-name-container .folder-name-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label {
+  padding: 5px 7px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.app-folder-dialog .folder-name-container .icon-button, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button, .app-folder-dialog .folder-name-container .background-app-item .close-button, .background-app-item .app-folder-dialog .folder-name-container .close-button {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.7);
+  border: none;
+  height: 32px;
+  width: 32px;
+  padding: 4px;
+  border-radius: 9999px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button > StIcon, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button > StIcon, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button > StIcon,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button > StIcon,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button > StIcon, .app-folder-dialog .folder-name-container .background-app-item .close-button > StIcon, .background-app-item .app-folder-dialog .folder-name-container .close-button > StIcon {
+  icon-size: 16px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button:hover, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:hover, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:hover,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:hover,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:hover, .app-folder-dialog .folder-name-container .background-app-item .close-button:hover, .background-app-item .app-folder-dialog .folder-name-container .close-button:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.app-folder-dialog .folder-name-container .icon-button:checked, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:checked, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:checked,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:checked,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:checked, .app-folder-dialog .folder-name-container .background-app-item .close-button:checked, .background-app-item .app-folder-dialog .folder-name-container .close-button:checked, .app-folder-dialog .folder-name-container .icon-button:active, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:active, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:active,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:active,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:active, .app-folder-dialog .folder-name-container .background-app-item .close-button:active, .background-app-item .app-folder-dialog .folder-name-container .close-button:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder-dialog .icon-grid {
+  row-spacing: 12px;
+  column-spacing: 30px;
+  page-padding-top: 0;
+  page-padding-bottom: 0;
+  page-padding-left: 0;
+  page-padding-right: 0;
+}
+
+.app-folder-dialog .page-indicators {
+  margin-bottom: 18px;
+}
+
+.rename-folder-popup .rename-folder-popup-item {
+  spacing: 4px;
+}
+
+.rename-folder-popup .rename-folder-popup-item:ltr, .rename-folder-popup .rename-folder-popup-item:rtl {
+  padding: 0 8px;
+}
+
+.app-menu,
+.app-well-menu {
+  max-width: 27.25em;
+}
+
+.page-indicator {
+  padding: 4px 8px 0;
+}
+
+.page-indicator .page-indicator-icon {
+  width: 10px;
+  height: 10px;
+  border-radius: 10px;
+  background-color: white;
+  transition-duration: 400ms;
+}
+
+.apps-scroll-view {
+  padding: 0;
+}
+
+.system-action-icon {
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  border-radius: 9999px;
+}
+
+.page-navigation-hint.dnd {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.page-navigation-hint.next:ltr, .page-navigation-hint.previous:rtl {
+  background-gradient-start: rgba(255, 255, 255, 0.05);
+  background-gradient-end: transparent;
+  background-gradient-direction: horizontal;
+  border-radius: 15px 0px 0px 15px;
+}
+
+.page-navigation-hint.previous:ltr, .page-navigation-hint.next:rtl {
+  background-gradient-start: transparent;
+  background-gradient-end: rgba(255, 255, 255, 0.05);
+  background-gradient-direction: horizontal;
+  border-radius: 0px 15px 15px 0px;
+}
+
+.page-navigation-arrow {
+  margin: 6px;
+  padding: 18px;
+  width: 24px;
+  height: 24px;
+  border-radius: 9999px;
+  color: white;
+  background-color: transparent;
+}
+
+.page-navigation-arrow:insensitive {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.page-navigation-arrow:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.page-navigation-arrow:active {
+  background-color: rgba(255, 255, 255, 0.24);
+  color: white;
+}
+
+/* Workspace pager */
+.workspace-thumbnails .workspace-thumbnail {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border: none;
+}
+
+.workspace-thumbnails {
+  visible-width: 32px;
+  spacing: 4px;
+  padding: 4px;
+}
+
+.workspace-thumbnails .workspace-thumbnail {
+  border-radius: 3px;
+}
+
+.workspace-thumbnails .placeholder {
+  background-image: url("resource:///org/gnome/shell/theme/dash-placeholder.svg");
+  background-size: contain;
+  width: 18px;
+}
+
+.workspace-thumbnail-indicator {
+  border: 3px solid #3281EA;
+  border-radius: 3px;
+  padding: 0px;
+}
+
+.ripple-pointer-location {
+  width: 48px;
+  height: 48px;
+  border-radius: 24px;
+  background-color: rgba(189, 214, 248, 0.3);
+  box-shadow: 0 0 2px 2px #8fbaf3;
+}
+
+.pie-timer {
+  width: 60px;
+  height: 60px;
+  -pie-border-width: 3px;
+  -pie-border-color: #3281EA;
+  -pie-background-color: rgba(235, 243, 253, 0.3);
+}
+
+.magnifier-zoom-region {
+  border: 2px solid #3281EA;
+}
+
+.magnifier-zoom-region.full-screen {
+  border-width: 0;
+}
+
+.select-area-rubberband {
+  background-color: rgba(50, 129, 234, 0.3);
+  border: 1px solid #3281EA;
+}
+
+.user-icon {
+  background-size: contain;
+  color: rgba(255, 255, 255, 0.7);
+  border-radius: 9999px;
+  icon-size: 64px;
+}
+
+.user-icon:hover {
+  color: white;
+}
+
+.user-icon StIcon {
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 99px;
+  padding: 8px;
+  width: 40px;
+  height: 40px;
+}
+
+.user-icon.user-avatar {
+  border: 2px rgba(255, 255, 255, 0.7);
+}
+
+.user-widget.vertical .user-icon {
+  icon-size: 128px;
+}
+
+.user-widget.vertical .user-icon StIcon {
+  padding: 14px;
+  padding-top: 12px;
+  padding-bottom: 16px;
+  width: 88px;
+  height: 88px;
+}
+
+.lightbox {
+  background-color: black;
+}
+
+.flashspot {
+  background-color: white;
+}
+
+.hidden {
+  color: rgba(0, 0, 0, 0);
+}
+
+.caps-lock-warning-label {
+  text-align: center;
+  padding-bottom: 8px;
+  font-size: 9.75pt;
+  font-weight: 400;
+  color: #FBC02D;
+}
+
+/* Workspace animation */
+.workspace-animation {
+  background-color: #242424;
+}
+
+/* Tiled window previews */
+.tile-preview {
+  background-color: rgba(50, 129, 234, 0.3);
+  border: 1px solid #3281EA;
+}
+
+.tile-preview-left.on-primary {
+  border-radius: 11px 0 0 0;
+}
+
+.tile-preview-right.on-primary {
+  border-radius: 0 11px 0 0;
+}
+
+.tile-preview-left.tile-preview-right.on-primary {
+  border-radius: 11px 11px 0 0;
+}
+
+/* On-screen Keyboard */
+#keyboard {
+  background-color: rgba(0, 0, 0, 0.85);
+  border: none;
+  border-top-width: 0;
+  box-shadow: none;
+}
+
+#keyboard .page-indicator {
+  padding: 4px;
+}
+
+#keyboard .page-indicator .page-indicator-icon {
+  width: 8px;
+  height: 8px;
+}
+
+.key-container {
+  padding: 2px;
+  spacing: 2px;
+}
+
+.keyboard-key {
+  min-height: 2em;
+  min-width: 2em;
+  font-size: 14pt;
+  font-weight: bold;
+  border-radius: 10px;
+  border: none;
+  color: inherit;
+  background-color: #212121;
+  box-shadow: 0 1px rgba(0, 0, 0, 0.2);
+}
+
+.keyboard-key:focus, .keyboard-key:hover {
+  color: white;
+  background-color: #3b3b3b;
+}
+
+.keyboard-key:checked, .keyboard-key:active {
+  color: white;
+  background-color: #545454;
+}
+
+.keyboard-key:grayed {
+  background-color: #242424;
+  color: white;
+  border-color: #242424;
+}
+
+.keyboard-key.default-key {
+  background-color: #0F0F0F;
+  box-shadow: 0 1px rgba(0, 0, 0, 0.2);
+}
+
+.keyboard-key.default-key:focus, .keyboard-key.default-key:hover {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: #212121;
+}
+
+.keyboard-key.default-key:checked, .keyboard-key.default-key:active {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: #121212;
+}
+
+.keyboard-key.enter-key {
+  background-color: #3281EA;
+  color: white;
+}
+
+.keyboard-key.enter-key:focus, .keyboard-key.enter-key:hover {
+  color: white;
+  background-color: #498fec;
+}
+
+.keyboard-key.enter-key:checked, .keyboard-key.enter-key:active {
+  color: white;
+  background-color: #1667d3;
+}
+
+.keyboard-key.shift-key-uppercase {
+  color: #3281EA;
+}
+
+.keyboard-key StIcon {
+  icon-size: 1.125em;
+}
+
+.keyboard-subkeys {
+  color: inherit;
+  -arrow-border-radius: 10px;
+  -arrow-background-color: rgba(0, 0, 0, 0.45);
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
+  -boxpointer-gap: 5px;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.32);
+}
+
+.emoji-page .keyboard-key {
+  background-color: transparent;
+  border: none;
+  color: initial;
+}
+
+.emoji-panel .keyboard-key:latched {
+  border-color: #498fec;
+  background-color: #3281EA;
+}
+
+.word-suggestions {
+  font-size: 14pt;
+  spacing: 12px;
+  min-height: 20pt;
+}
+
+/* Looking Glass */
+#LookingGlassDialog {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: #242424;
+  spacing: 4px;
+  padding: 0;
+  border: none;
+  border-radius: 16px;
+  box-shadow: 0 10px 15px rgba(0, 0, 0, 0.45);
+}
+
+#LookingGlassDialog > #Toolbar {
+  padding: 4px 6px;
+  border: none;
+  border-radius: 16px 16px 0 0;
+  background-color: #3e3e3e;
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+#LookingGlassDialog .labels {
+  spacing: 0;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+#LookingGlassDialog .notebook-tab {
+  -natural-hpadding: 4px;
+  -minimum-hpadding: 4px;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.5);
+  transition-duration: 150ms;
+  padding-left: 12px;
+  padding-right: 12px;
+  min-height: 22px;
+  border-radius: 10px;
+  background-color: transparent;
+}
+
+#LookingGlassDialog .notebook-tab:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.15);
+  text-shadow: none;
+  box-shadow: none;
+}
+
+#LookingGlassDialog .notebook-tab:selected {
+  background-color: rgba(255, 255, 255, 0.1);
+  box-shadow: none;
+  color: white;
+  text-shadow: none;
+}
+
+#LookingGlassDialog StBoxLayout#EvalBox {
+  padding: 4px;
+  spacing: 4px;
+}
+
+#LookingGlassDialog StBoxLayout#ResultsArea {
+  spacing: 4px;
+}
+
+.lg-dialog StEntry {
+  selection-background-color: #3281EA;
+  selected-color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.lg-dialog .shell-link {
+  color: #3281EA;
+}
+
+.lg-dialog .shell-link:hover {
+  color: #3281EA;
+}
+
+.lg-dialog .actor-link {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.lg-dialog .actor-link:hover {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.lg-dialog .actor-link:active {
+  color: rgba(204, 204, 204, 0.5);
+}
+
+.lg-dialog .actor-link StIcon {
+  icon-size: 12px;
+}
+
+.lg-completions-text {
+  font-size: 1em;
+  font-style: italic;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lg-obj-inspector-title {
+  spacing: 4px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lg-obj-inspector-button {
+  min-height: 32px;
+  padding: 4px;
+  border: none;
+  border-radius: 10px;
+  font-size: 9.75pt;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.lg-obj-inspector-button:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.lg-obj-inspector-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.lg-obj-inspector-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.lg-obj-inspector-button:focus {
+  color: white;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.lg-obj-inspector-button:hover {
+  border: none;
+}
+
+#lookingGlassExtensions {
+  padding: 4px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lg-extensions-list {
+  padding: 4px;
+  spacing: 4px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lg-extension {
+  border: none;
+  border-radius: 10px;
+  background-color: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.7);
+  padding: 4px;
+  box-shadow: none;
+}
+
+.lg-extension-name {
+  font-size: 18pt;
+  font-weight: 400;
+  color: white;
+}
+
+.lg-extension-meta {
+  spacing: 4px;
+}
+
+#LookingGlassPropertyInspector {
+  color: white;
+  background: #333333;
+  border: none;
+  border-radius: 10px;
+  padding: 4px;
+  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.32);
+}
+
+#LookingGlassPropertyInspector .window-close, #LookingGlassPropertyInspector .screenshot-ui-close-button {
+  margin: 4px;
+}
+
+.lg-debug-flag-button {
+  color: white;
+}
+
+.lg-debug-flag-button StLabel {
+  padding: 4px, 8px;
+}
+
+.lg-debug-flag-button:hover {
+  color: white;
+}
+
+.lg-debug-flag-button:active {
+  color: #cccccc;
+}
+
+.lg-debug-flags-header {
+  padding-top: 8px;
+  padding: 4px;
+}
+
+.icon-label-button-container {
+  spacing: 4px;
+  font-size: 9pt;
+  font-weight: 400;
+}
+
+.icon-label-button-container StIcon {
+  icon-size: 32px;
+}
+
+.screenshot-ui-panel {
+  color: white;
+  background-color: #212121;
+  border: none;
+  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.32);
+  border-radius: 31px;
+  padding: 12px;
+  padding-bottom: 6px;
+  margin-bottom: 4em;
+  spacing: 8px;
+}
+
+.screenshot-ui-close-button {
+  padding: 4px !important;
+}
+
+.screenshot-ui-close-button.left {
+  margin-left: 6px;
+}
+
+.screenshot-ui-close-button.right {
+  margin-right: 6px;
+}
+
+.screenshot-ui-type-button {
+  min-width: 48px;
+  padding: 8px 12px !important;
+  border-radius: 19px;
+}
+
+.screenshot-ui-capture-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 9999px;
+  border: 4px white;
+  padding: 2px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle {
+  background-color: white;
+  transition-duration: 200ms;
+  border-radius: 9999px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle:hover, .screenshot-ui-capture-button .screenshot-ui-capture-button-circle:focus {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.screenshot-ui-capture-button:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:focus .screenshot-ui-capture-button-circle {
+  background-color: #d9d9d9;
+}
+
+.screenshot-ui-capture-button:active .screenshot-ui-capture-button-circle {
+  background-color: gray;
+}
+
+.screenshot-ui-capture-button:cast .screenshot-ui-capture-button-circle {
+  background-color: #F44336;
+}
+
+.screenshot-ui-capture-button:cast:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:cast:focus .screenshot-ui-capture-button-circle {
+  background-color: #f55a4e;
+}
+
+.screenshot-ui-capture-button:cast:active .screenshot-ui-capture-button-circle {
+  background-color: #f22314;
+}
+
+.screenshot-ui-shot-cast-container {
+  background-color: rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 3px;
+  spacing: 3px;
+}
+
+.screenshot-ui-shot-cast-container:ltr {
+  margin-left: 9px;
+}
+
+.screenshot-ui-shot-cast-container:rtl {
+  margin-right: 9px;
+}
+
+.screenshot-ui-shot-cast-button {
+  padding: 4px 8px;
+  background-color: transparent;
+  border-radius: 7px;
+}
+
+.screenshot-ui-shot-cast-button:hover, .screenshot-ui-shot-cast-button:focus {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.screenshot-ui-shot-cast-button:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.screenshot-ui-shot-cast-button:checked {
+  background-color: white;
+  color: black;
+}
+
+.screenshot-ui-shot-cast-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-show-pointer-button {
+  border-radius: 9999px;
+  padding: 8px !important;
+}
+
+.screenshot-ui-show-pointer-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-selection {
+  border: 2px white;
+}
+
+.screenshot-ui-area-selector-handle {
+  border-radius: 9999px;
+  background-color: white;
+  box-shadow: 0 1px 3px 2px rgba(0, 0, 0, 0.2);
+  width: 24px;
+  height: 24px;
+}
+
+.screenshot-ui-window-selector {
+  background-color: #242424;
+}
+
+.screenshot-ui-window-selector .screenshot-ui-window-selector-window-container {
+  margin: 100px;
+}
+
+.screenshot-ui-window-selector:primary-monitor .screenshot-ui-window-selector-window-container {
+  margin-bottom: 200px;
+}
+
+.screenshot-ui-window-selector-window-border {
+  transition-duration: 200ms;
+  border-radius: 10px;
+  border: 6px transparent;
+}
+
+.screenshot-ui-window-selector-check {
+  transition-duration: 200ms;
+  color: transparent;
+  border-radius: 9999px;
+  border-width: 12px;
+  icon-size: 24px;
+}
+
+.screenshot-ui-window-selector-window:hover .screenshot-ui-window-selector-window-border {
+  border-color: #135cbc;
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-window-border {
+  border-color: #3281EA;
+  background-color: rgba(50, 129, 234, 0.2);
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-check {
+  color: white;
+  background-color: #3281EA;
+}
+
+.screenshot-ui-screen-selector {
+  transition-duration: 200ms;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-screen-selector:hover {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-screen-selector:active {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.screenshot-ui-screen-selector:checked {
+  background-color: transparent;
+  border: 2px white;
+}
+
+.screenshot-ui-tooltip {
+  color: white;
+  background-color: #242424;
+  border-radius: 9999px;
+  padding: 4px 8px;
+  text-align: center;
+  -y-offset: 24px;
+}
+
+/* Login Dialog */
+.login-dialog-banner-view {
+  padding-top: 24px;
+  max-width: 23em;
+}
+
+.login-dialog,
+.unlock-dialog {
+  border: none;
+  background-color: transparent;
+}
+
+.login-dialog StEntry,
+.unlock-dialog StEntry {
+  selection-background-color: #3281EA;
+  selected-color: white !important;
+  caret-color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.12);
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.login-dialog StEntry:focus,
+.unlock-dialog StEntry:focus {
+  color: white;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #3281EA !important;
+}
+
+.login-dialog StEntry:insensitive,
+.unlock-dialog StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .modal-dialog-button-box,
+.unlock-dialog .modal-dialog-button-box {
+  spacing: 3px;
+}
+
+.login-dialog .modal-dialog-button,
+.unlock-dialog .modal-dialog-button {
+  padding: 4px 18px;
+  box-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:hover, .login-dialog .modal-dialog-button:focus,
+.unlock-dialog .modal-dialog-button:hover,
+.unlock-dialog .modal-dialog-button:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:active,
+.unlock-dialog .modal-dialog-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:insensitive,
+.unlock-dialog .modal-dialog-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default,
+.unlock-dialog .modal-dialog-button:default {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: #3281EA;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:hover, .login-dialog .modal-dialog-button:default:focus,
+.unlock-dialog .modal-dialog-button:default:hover,
+.unlock-dialog .modal-dialog-button:default:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:active,
+.unlock-dialog .modal-dialog-button:default:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.24);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:insensitive,
+.unlock-dialog .modal-dialog-button:default:insensitive {
+  color: rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .cancel-button,
+.login-dialog .switch-user-button,
+.login-dialog .login-dialog-session-list-button,
+.unlock-dialog .cancel-button,
+.unlock-dialog .switch-user-button,
+.unlock-dialog .login-dialog-session-list-button {
+  padding: 0;
+  border-radius: 99px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background-color: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .cancel-button:hover, .login-dialog .cancel-button:focus,
+.login-dialog .switch-user-button:hover,
+.login-dialog .switch-user-button:focus,
+.login-dialog .login-dialog-session-list-button:hover,
+.login-dialog .login-dialog-session-list-button:focus,
+.unlock-dialog .cancel-button:hover,
+.unlock-dialog .cancel-button:focus,
+.unlock-dialog .switch-user-button:hover,
+.unlock-dialog .switch-user-button:focus,
+.unlock-dialog .login-dialog-session-list-button:hover,
+.unlock-dialog .login-dialog-session-list-button:focus {
+  color: white;
+}
+
+.login-dialog .cancel-button:active,
+.login-dialog .switch-user-button:active,
+.login-dialog .login-dialog-session-list-button:active,
+.unlock-dialog .cancel-button:active,
+.unlock-dialog .switch-user-button:active,
+.unlock-dialog .login-dialog-session-list-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.login-dialog .cancel-button StIcon,
+.login-dialog .switch-user-button StIcon,
+.login-dialog .login-dialog-session-list-button StIcon,
+.unlock-dialog .cancel-button StIcon,
+.unlock-dialog .switch-user-button StIcon,
+.unlock-dialog .login-dialog-session-list-button StIcon {
+  icon-size: 16px;
+}
+
+.login-dialog .caps-lock-warning-label,
+.login-dialog .login-dialog-message-warning,
+.unlock-dialog .caps-lock-warning-label,
+.unlock-dialog .login-dialog-message-warning {
+  color: white;
+}
+
+.login-dialog-logo-bin {
+  padding: 24px 0px;
+}
+
+.login-dialog-banner {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-button-box {
+  width: 23em;
+  spacing: 5px;
+}
+
+.login-dialog-message {
+  text-align: center;
+}
+
+.login-dialog-user-selection-box {
+  padding: 100px 0px;
+}
+
+.login-dialog-not-listed-label {
+  padding-left: 2px;
+  font-size: 1em;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.7);
+  padding-top: 1em;
+}
+
+.login-dialog-not-listed-label:hover {
+  color: white;
+}
+
+.login-dialog-not-listed-label:focus {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.login-dialog-not-listed-button:focus .login-dialog-not-listed-label, .login-dialog-not-listed-button:hover .login-dialog-not-listed-label {
+  color: white;
+}
+
+.login-dialog-user-list-view {
+  -st-vfade-offset: 1em;
+}
+
+.login-dialog-user-list {
+  spacing: 12px;
+  width: 23em;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:selected {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: white;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:logged-in {
+  border-right: 2px solid white;
+}
+
+.login-dialog-user-list-item {
+  border-radius: 10px;
+  padding: 6px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-user-list-item:ltr {
+  padding-right: 1em;
+}
+
+.login-dialog-user-list-item:rtl {
+  padding-left: 1em;
+}
+
+.login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: white;
+}
+
+.login-dialog-user-list-item .login-dialog-timed-login-indicator {
+  height: 2px;
+  margin: 6px 0 0 0;
+  background-color: white;
+}
+
+.login-dialog-user-list-item:focus .login-dialog-timed-login-indicator {
+  background-color: white;
+}
+
+.user-widget-label {
+  color: white;
+}
+
+.user-widget.horizontal .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+  padding-left: 15px;
+}
+
+.user-widget.horizontal .user-widget-label:ltr {
+  padding-left: 14px;
+  text-align: left;
+}
+
+.user-widget.horizontal .user-widget-label:rtl {
+  padding-right: 14px;
+  text-align: right;
+}
+
+.user-widget.vertical .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  text-align: center;
+  font-weight: normal;
+  padding-top: 16px;
+}
+
+.login-dialog-prompt-layout {
+  padding-top: 24px;
+  padding-bottom: 12px;
+  spacing: 8px;
+  width: 23em;
+}
+
+.login-dialog-prompt-entry {
+  height: 1.5em;
+}
+
+.login-dialog-prompt-label {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 1em;
+  padding-top: 1em;
+}
+
+/* Screen Shield */
+.unlock-dialog-clock {
+  color: white;
+  font-weight: 300;
+  text-align: center;
+  spacing: 24px;
+  padding-bottom: 2.5em;
+}
+
+.unlock-dialog-clock-time {
+  font-size: 64pt;
+  padding-top: 42px;
+  font-feature-settings: "tnum";
+}
+
+.unlock-dialog-clock-date {
+  font-size: 16pt;
+  font-weight: normal;
+}
+
+.unlock-dialog-clock-hint {
+  font-weight: normal;
+  padding-top: 48px;
+}
+
+.unlock-dialog-notifications-container {
+  margin: 12px 0;
+  spacing: 6px;
+  width: 23em;
+  background-color: transparent;
+}
+
+.unlock-dialog-notifications-container .summary-notification-stack-scrollview {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.unlock-dialog-notifications-container .notification,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source {
+  padding: 12px 6px;
+  border: none;
+  background-color: rgba(25, 25, 25, 0.9);
+  color: white;
+  border-radius: 10px;
+}
+
+.unlock-dialog-notifications-container .notification.critical,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source.critical {
+  background-color: rgba(36, 36, 36, 0.9);
+}
+
+.unlock-dialog-notification-label {
+  padding: 0px 0px 0px 12px;
+}
+
+.unlock-dialog-notification-count-text {
+  weight: bold;
+  padding: 0 6px;
+  color: rgba(25, 25, 25, 0.9);
+  background-color: rgba(255, 255, 255, 0.7);
+  border-radius: 99px;
+  margin-right: 12px;
+}
+
+.screen-shield-background {
+  background: black;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.6);
+}
+
+#lockDialogGroup {
+  background-color: #242424;
+}
+
+#unlockDialogNotifications StButton#vhandle, #unlockDialogNotifications StButton#hhandle {
+  background-color: rgba(25, 25, 25, 0.2);
+}
+
+#unlockDialogNotifications StButton#vhandle:hover, #unlockDialogNotifications StButton#vhandle:focus, #unlockDialogNotifications StButton#hhandle:hover, #unlockDialogNotifications StButton#hhandle:focus {
+  background-color: rgba(25, 25, 25, 0.4);
+}
+
+#unlockDialogNotifications StButton#vhandle:active, #unlockDialogNotifications StButton#hhandle:active {
+  background-color: rgba(50, 129, 234, 0.5);
+}
+
+.bottom #dashtodockDashScrollview,
+.top #dashtodockDashScrollview {
+  -st-hfade-offset: 24px;
+}
+
+.left #dashtodockDashScrollview,
+.right #dashtodockDashScrollview {
+  -st-vfade-offset: 24px;
+}
+
+#dashtodockContainer {
+  background: transparent;
+}
+
+#dashtodockContainer .number-overlay {
+  min-width: 1.2em;
+  min-height: 1.2em;
+  color: white;
+  background-color: rgba(0, 0, 0, 0.75);
+  text-align: center;
+  padding: 0.2em 0.4em;
+}
+
+#dashtodockContainer .notification-badge {
+  min-width: 16px;
+  min-height: 16px;
+  color: white;
+  background-color: #3281EA;
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.25);
+  border-radius: 9999px;
+  margin: 2px 3px 5px;
+  padding: 0.2em 0.4em;
+  font-weight: bold;
+  text-align: center;
+}
+
+#dashtodockContainer.top #dash .dash-background {
+  border-radius: 9999px !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash, #dashtodockContainer.top.shrink.straight-corner #dash, #dashtodockContainer.top.extended #dash, #dashtodockContainer.top.shrink.extended #dash {
+  margin: 0 !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .dash-background, #dashtodockContainer.top.shrink.straight-corner #dash .dash-background, #dashtodockContainer.top.extended #dash .dash-background, #dashtodockContainer.top.shrink.extended #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .show-apps,
+#dashtodockContainer.top.straight-corner #dash .overview-tile,
+#dashtodockContainer.top.straight-corner #dash .grid-search-result, #dashtodockContainer.top.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.top.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.top.extended #dash .show-apps,
+#dashtodockContainer.top.extended #dash .overview-tile,
+#dashtodockContainer.top.extended #dash .grid-search-result, #dashtodockContainer.top.shrink.extended #dash .show-apps,
+#dashtodockContainer.top.shrink.extended #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.bottom #dash .dash-background {
+  border-radius: 9999px !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash, #dashtodockContainer.bottom.shrink.straight-corner #dash, #dashtodockContainer.bottom.extended #dash, #dashtodockContainer.bottom.shrink.extended #dash {
+  margin: 0 !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .dash-background, #dashtodockContainer.bottom.shrink.straight-corner #dash .dash-background, #dashtodockContainer.bottom.extended #dash .dash-background, #dashtodockContainer.bottom.shrink.extended #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.straight-corner #dash .overview-tile,
+#dashtodockContainer.bottom.straight-corner #dash .grid-search-result, #dashtodockContainer.bottom.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.bottom.extended #dash .show-apps,
+#dashtodockContainer.bottom.extended #dash .overview-tile,
+#dashtodockContainer.bottom.extended #dash .grid-search-result, #dashtodockContainer.bottom.shrink.extended #dash .show-apps,
+#dashtodockContainer.bottom.shrink.extended #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.left #dash .dash-background {
+  border-radius: 9999px !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash, #dashtodockContainer.left.shrink.straight-corner #dash, #dashtodockContainer.left.extended #dash, #dashtodockContainer.left.shrink.extended #dash {
+  margin: 0 !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .dash-background, #dashtodockContainer.left.shrink.straight-corner #dash .dash-background, #dashtodockContainer.left.extended #dash .dash-background, #dashtodockContainer.left.shrink.extended #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .show-apps,
+#dashtodockContainer.left.straight-corner #dash .overview-tile,
+#dashtodockContainer.left.straight-corner #dash .grid-search-result, #dashtodockContainer.left.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.left.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.left.extended #dash .show-apps,
+#dashtodockContainer.left.extended #dash .overview-tile,
+#dashtodockContainer.left.extended #dash .grid-search-result, #dashtodockContainer.left.shrink.extended #dash .show-apps,
+#dashtodockContainer.left.shrink.extended #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.right #dash .dash-background {
+  border-radius: 9999px !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash, #dashtodockContainer.right.shrink.straight-corner #dash, #dashtodockContainer.right.extended #dash, #dashtodockContainer.right.shrink.extended #dash {
+  margin: 0 !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .dash-background, #dashtodockContainer.right.shrink.straight-corner #dash .dash-background, #dashtodockContainer.right.extended #dash .dash-background, #dashtodockContainer.right.shrink.extended #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .show-apps,
+#dashtodockContainer.right.straight-corner #dash .overview-tile,
+#dashtodockContainer.right.straight-corner #dash .grid-search-result, #dashtodockContainer.right.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.right.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.right.extended #dash .show-apps,
+#dashtodockContainer.right.extended #dash .overview-tile,
+#dashtodockContainer.right.extended #dash .grid-search-result, #dashtodockContainer.right.shrink.extended #dash .show-apps,
+#dashtodockContainer.right.shrink.extended #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.extended .dash-background, #dashtodockContainer.straight-corner .dash-background {
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.shrink .dash-background {
+  padding: 2px !important;
+}
+
+#dashtodockContainer.shrink .show-apps,
+#dashtodockContainer.shrink .overview-tile,
+#dashtodockContainer.shrink .grid-search-result {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.shrink.extended .dash-background {
+  border-radius: 0;
+}
+
+#dashtodockContainer #dash, #dashtodockContainer:overview #dash {
+  background: transparent;
+}
+
+#dashtodockContainer.left #dash, #dashtodockContainer.right #dash {
+  margin-top: 0 !important;
+  padding: 12px !important;
+}
+
+#dashtodockContainer.left #dash #dashtodockDashContainer, #dashtodockContainer.right #dash #dashtodockDashContainer {
+  padding: 10px 0 !important;
+}
+
+#dashtodockContainer.left .show-apps,
+#dashtodockContainer.left .overview-tile,
+#dashtodockContainer.left .grid-search-result, #dashtodockContainer.right .show-apps,
+#dashtodockContainer.right .overview-tile,
+#dashtodockContainer.right .grid-search-result {
+  padding: 2px 4px !important;
+}
+
+#dashtodockContainer.left .dash-background, #dashtodockContainer.right .dash-background {
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.left.shrink #dash #dashtodockDashContainer, #dashtodockContainer.right.shrink #dash #dashtodockDashContainer {
+  padding: 2px 0 !important;
+}
+
+#dashtodockContainer.left.shrink .dash-background, #dashtodockContainer.right.shrink .dash-background {
+  padding: 2px !important;
+}
+
+#dashtodockContainer.left.shrink .show-apps,
+#dashtodockContainer.left.shrink .overview-tile,
+#dashtodockContainer.left.shrink .grid-search-result, #dashtodockContainer.right.shrink .show-apps,
+#dashtodockContainer.right.shrink .overview-tile,
+#dashtodockContainer.right.shrink .grid-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer, #dashtodockContainer.right.extended #dash #dashtodockDashContainer, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.right.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child {
+  padding-top: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.right.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child {
+  padding-bottom: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.right.extended #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer > :first-child .show-apps {
+  padding-bottom: 4px !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.right.extended #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer > :last-child .show-apps {
+  padding-bottom: 20px !important;
+}
+
+#dashtodockContainer.left.extended.shrink .dash-background, #dashtodockContainer.left.straight-corner.shrink .dash-background, #dashtodockContainer.right.extended.shrink .dash-background, #dashtodockContainer.right.straight-corner.shrink .dash-background {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended.shrink .show-apps,
+#dashtodockContainer.left.extended.shrink .overview-tile,
+#dashtodockContainer.left.extended.shrink .grid-search-result, #dashtodockContainer.left.straight-corner.shrink .show-apps,
+#dashtodockContainer.left.straight-corner.shrink .overview-tile,
+#dashtodockContainer.left.straight-corner.shrink .grid-search-result, #dashtodockContainer.right.extended.shrink .show-apps,
+#dashtodockContainer.right.extended.shrink .overview-tile,
+#dashtodockContainer.right.extended.shrink .grid-search-result, #dashtodockContainer.right.straight-corner.shrink .show-apps,
+#dashtodockContainer.right.straight-corner.shrink .overview-tile,
+#dashtodockContainer.right.straight-corner.shrink .grid-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended .overview-tile, #dashtodockContainer.left.extended .grid-search-result, #dashtodockContainer.left.straight-corner .overview-tile, #dashtodockContainer.left.straight-corner .grid-search-result, #dashtodockContainer.right.extended .overview-tile, #dashtodockContainer.right.extended .grid-search-result, #dashtodockContainer.right.straight-corner .overview-tile, #dashtodockContainer.right.straight-corner .grid-search-result {
+  padding: 2px 12px !important;
+}
+
+#dashtodockContainer.left.extended .show-apps, #dashtodockContainer.left.straight-corner .show-apps, #dashtodockContainer.right.extended .show-apps, #dashtodockContainer.right.straight-corner .show-apps {
+  padding: 2px 12px 24px !important;
+}
+
+#dashtodockContainer.top .dash-background, #dashtodockContainer.bottom .dash-background {
+  padding: 12px 10px !important;
+}
+
+#dashtodockContainer.top .show-apps,
+#dashtodockContainer.top .overview-tile,
+#dashtodockContainer.top .grid-search-result, #dashtodockContainer.bottom .show-apps,
+#dashtodockContainer.bottom .overview-tile,
+#dashtodockContainer.bottom .grid-search-result {
+  margin: 0 2px !important;
+  padding-bottom: 12px !important;
+}
+
+#dashtodockContainer.top .show-apps .overview-icon,
+#dashtodockContainer.top .overview-tile .overview-icon,
+#dashtodockContainer.top .grid-search-result .overview-icon, #dashtodockContainer.bottom .show-apps .overview-icon,
+#dashtodockContainer.bottom .overview-tile .overview-icon,
+#dashtodockContainer.bottom .grid-search-result .overview-icon {
+  padding: 4px !important;
+  spacing: 4px !important;
+}
+
+#dashtodockContainer.top.shrink .dash-background, #dashtodockContainer.bottom.shrink .dash-background {
+  padding: 2px 1px !important;
+}
+
+#dashtodockContainer.top.shrink .show-apps,
+#dashtodockContainer.top.shrink .overview-tile,
+#dashtodockContainer.top.shrink .grid-search-result, #dashtodockContainer.bottom.shrink .show-apps,
+#dashtodockContainer.bottom.shrink .overview-tile,
+#dashtodockContainer.bottom.shrink .grid-search-result {
+  margin: 0 !important;
+  padding: 0 1px 12px !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child {
+  padding-left: 0 !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child {
+  padding-right: 0 !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer > :first-child .show-apps {
+  padding-left: 0 !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer > :last-child .show-apps {
+  padding-right: 16px !important;
+}
+
+#dashtodockContainer.top.extended.shrink .dash-background, #dashtodockContainer.top.straight-corner.shrink .dash-background, #dashtodockContainer.bottom.extended.shrink .dash-background, #dashtodockContainer.bottom.straight-corner.shrink .dash-background {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.extended.shrink .show-apps,
+#dashtodockContainer.top.extended.shrink .overview-tile,
+#dashtodockContainer.top.extended.shrink .grid-search-result, #dashtodockContainer.top.straight-corner.shrink .show-apps,
+#dashtodockContainer.top.straight-corner.shrink .overview-tile,
+#dashtodockContainer.top.straight-corner.shrink .grid-search-result, #dashtodockContainer.bottom.extended.shrink .show-apps,
+#dashtodockContainer.bottom.extended.shrink .overview-tile,
+#dashtodockContainer.bottom.extended.shrink .grid-search-result, #dashtodockContainer.bottom.straight-corner.shrink .show-apps,
+#dashtodockContainer.bottom.straight-corner.shrink .overview-tile,
+#dashtodockContainer.bottom.straight-corner.shrink .grid-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.extended .dash-separator, #dashtodockContainer.top.straight-corner .dash-separator, #dashtodockContainer.bottom.extended .dash-separator, #dashtodockContainer.bottom.straight-corner .dash-separator {
+  margin: 0 8px !important;
+}
+
+#dashtodockContainer.top.extended .show-apps,
+#dashtodockContainer.top.extended .overview-tile,
+#dashtodockContainer.top.extended .grid-search-result, #dashtodockContainer.top.straight-corner .show-apps,
+#dashtodockContainer.top.straight-corner .overview-tile,
+#dashtodockContainer.top.straight-corner .grid-search-result, #dashtodockContainer.bottom.extended .show-apps,
+#dashtodockContainer.bottom.extended .overview-tile,
+#dashtodockContainer.bottom.extended .grid-search-result, #dashtodockContainer.bottom.straight-corner .show-apps,
+#dashtodockContainer.bottom.straight-corner .overview-tile,
+#dashtodockContainer.bottom.straight-corner .grid-search-result {
+  padding: 12px 2px !important;
+}
+
+#dashtodockContainer #dash .dash-background {
+  background-color: rgba(33, 33, 33, 0.65);
+}
+
+#dashtodockContainer #dash .app-grid-running-dot {
+  margin-bottom: 3px !important;
+  margin-top: 0 !important;
+  offset-y: 0 !important;
+}
+
+#dashtodockContainer #dash StWidget.focused .app-grid-running-dot {
+  background-color: #3281EA;
+}
+
+#dashtodockContainer.opaque #dash .dash-background {
+  background-color: #212121;
+}
+
+#dashtodockContainer.transparent #dash .dash-background {
+  background-color: rgba(33, 33, 33, 0.65);
+}
+
+#dashtodockContainer:overview #dash {
+  background: none;
+}
+
+#dashtodockContainer:overview #dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#dashtodockContainer:overview #dash StWidget.focused .app-grid-running-dot {
+  background-color: #3281EA;
+}
+
+#dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
+  background-color: transparent !important;
+  box-shadow: none !important;
+}
+
+#dashtodockContainer.opaque:overview .dash-background, #dashtodockContainer.transparent:overview .dash-background {
+  background-color: transparent !important;
+}
+
+#dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
+  background: none;
+}
+
+#dashtodockContainer.running-dots .dash-item-container > StButton, #dashtodockContainer.dashtodock .dash-item-container > StButton {
+  transition-duration: 250ms;
+  background-size: contain;
+}
+
+#dashtodockContainer.shrink .dash-item-container > StButton, #dashtodockContainer.dashtodock .dash-item-container > StButton {
+  padding: 1px 2px;
+}
+
+#dashtodockContainer.extended .overview-tile .overview-icon, #dashtodockContainer.extended .grid-search-result .overview-icon,
+#dashtodockContainer.extended .show-apps .overview-icon, #dashtodockContainer.extended:overview .overview-tile .overview-icon,
+#dashtodockContainer.extended:overview .show-apps .overview-icon {
+  border-radius: 10px;
+}
+
+#dashtodockContainer .metro .overview-icon {
+  border-radius: 0;
+}
+
+.dashtodock-app-well-preview-menu-item {
+  padding: 1em 1em 0.5em 1em;
+}
+
+#dashtodockPreviewSeparator.popup-separator-menu-item-horizontal {
+  width: 1px;
+  height: auto;
+  border-right-width: 1px;
+  margin: 32px 0;
+}
+
+.dash-label.bottom {
+  margin-bottom: 16px !important;
+}
+
+.dashtopanelMainPanel {
+  border-radius: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+.dashtopanelMainPanel .dash-background {
+  background-color: rgba(33, 33, 33, 0.65);
+  margin-bottom: 0 !important;
+  padding: 0 !important;
+  border-radius: 0 !important;
+}
+
+.dashtopanelMainPanel .overview-tile, .dashtopanelMainPanel .grid-search-result {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .overview-tile .overview-icon, .dashtopanelMainPanel .grid-search-result .overview-icon {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .show-apps {
+  color: white !important;
+  border-radius: 0 !important;
+}
+
+.dashtopanelMainPanel .show-apps:hover {
+  background: rgba(255, 255, 255, 0.12) !important;
+}
+
+.dashtopanelMainPanel .show-apps:active {
+  background: rgba(255, 255, 255, 0.3) !important;
+}
+
+.dashtopanelMainPanel .panel-button, .dashtopanelMainPanel .panel-button.clock-display .clock {
+  border-radius: 7px !important;
+  margin: 0 !important;
+}
+
+.dashtopanelMainPanel .arcmenu-menu-button {
+  border-radius: 5px !important;
+  padding: 8px 6px !important;
+}
+
+.popup-menu.panel-menu .popup-menu-content, .popup-menu.panel-menu.quick-settings .popup-menu-content {
+  margin-bottom: 2px !important;
+}
+
+.dashtopanelSecondaryMenu {
+  border-radius: 12px !important;
+}
+
+#preview-menu {
+  margin: 4px !important;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2) !important;
+  border-radius: 12px !important;
+  padding: 0 !important;
+}
+
+#dashtopanelPreviewScrollview {
+  padding: 12px 0 !important;
+  border-radius: 12px !important;
+  background: #0c0c0c !important;
+}
+
+.openweather-button, .openweather-button-action, .openweather-menu-button-container, .openweather-button-box {
+  border: 1px solid transparent;
+}
+
+.openweather-provider {
+  padding: 0 16px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.openweather-provider:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.openweather-provider:focus {
+  color: white;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.openweather-provider:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.openweather-current-icon, .openweather-current-summary, .openweather-current-summarybox {
+  background: none;
+  color: white;
+}
+
+.openweather-current-databox-values {
+  background: none;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.openweather-current-databox-captions {
+  background: none;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.openweather-forecast-icon, .openweather-forecast-summary {
+  background: none;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.openweather-forecast-day, .openweather-forecast-temperature {
+  background: none;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.openweather-sunrise-icon, .openweather-sunset-icon, .openweather-build-icon {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.popup-sub-menu .openweather-current-icon, .popup-sub-menu .openweather-current-summary, .popup-sub-menu .openweather-current-summarybox {
+  background: none;
+  color: rgba(0, 0, 0, 0.95);
+}
+
+.popup-sub-menu .openweather-current-databox-values {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.popup-sub-menu .openweather-current-databox-captions {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.popup-sub-menu .openweather-forecast-icon, .popup-sub-menu .openweather-forecast-summary {
+  color: rgba(0, 0, 0, 0.85);
+}
+
+.popup-sub-menu .openweather-forecast-day, .popup-sub-menu .openweather-forecast-temperature {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.popup-sub-menu .openweather-sunrise-icon, .popup-sub-menu .openweather-sunset-icon, .popup-sub-menu .openweather-build-icon {
+  color: rgba(0, 0, 0, 0.85);
+}
+
+.arcmenu-menu-button,
+.arcmenu-button {
+  border-width: 0 !important;
+  border-radius: 9999px !important;
+}
+
+.cosmic-solid-bg {
+  background-color: #242424;
+}
+
+.cosmic-dock #dock {
+  background-color: transparent;
+}
+
+.cosmic-dock #dock .dash-background {
+  background-color: rgba(33, 33, 33, 0.65);
+}
+
+.cosmic-dock.extended #dash {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding: 0 0;
+}
+
+.cosmic-dock.extended #dash .dash-background {
+  border-radius: 0;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.overview-components-transparent .search-entry,
+.overview-components-light .search-entry,
+.overview-components-dark .search-entry {
+  caret-color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.overview-components-transparent .search-entry .search-entry-icon,
+.overview-components-light .search-entry .search-entry-icon,
+.overview-components-dark .search-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.overview-components-transparent .search-entry StLabel.hint-text,
+.overview-components-light .search-entry StLabel.hint-text,
+.overview-components-dark .search-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.35) !important;
+}

--- a/src/gnome-shell/shell-48-0/gnome-shell-Dark-Compact.scss
+++ b/src/gnome-shell/shell-48-0/gnome-shell-Dark-Compact.scss
@@ -1,0 +1,10 @@
+$variant: 'dark';
+$topbar: 'dark';
+$compact: 'true';
+
+@import '../../_sass/variables';
+@import '../../_sass/colors';
+@import '../../_sass/gnome-shell/drawing';
+@import '../../_sass/gnome-shell/common';
+@import '../../_sass/gnome-shell/widgets-48-0';
+@import '../../_sass/gnome-shell/extensions-46-0';

--- a/src/gnome-shell/shell-48-0/gnome-shell-Dark.css
+++ b/src/gnome-shell/shell-48-0/gnome-shell-Dark.css
@@ -1,0 +1,5097 @@
+/* This stylesheet is generated, DO NOT EDIT */
+stage {
+  font-size: 10.5pt;
+  font-weight: 400;
+  color: white;
+}
+
+.search-statustext {
+  font-size: 45px;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.modal-dialog .modal-dialog-linked-button, .hotplug-notification-item {
+  border: none;
+  margin-bottom: 6px;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.04);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+  font-size: 10.5pt;
+  font-weight: 500;
+}
+
+.modal-dialog .modal-dialog-linked-button:hover, .hotplug-notification-item:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.modal-dialog .modal-dialog-linked-button:active, .hotplug-notification-item:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.24);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+  color: white !important;
+}
+
+.modal-dialog .modal-dialog-linked-button:insensitive, .hotplug-notification-item:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: rgba(255, 255, 255, 0.04);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.modal-dialog .modal-dialog-linked-button:focus, .hotplug-notification-item:focus {
+  color: #3281EA;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.modal-dialog .modal-dialog-linked-button:focus:active, .hotplug-notification-item:focus:active {
+  color: white;
+}
+
+.modal-dialog .modal-dialog-linked-button:first-child, .hotplug-notification-item:first-child {
+  margin-left: 6px !important;
+  margin-right: 0 !important;
+  border-radius: 9999px 0 0 9999px;
+}
+
+.modal-dialog .modal-dialog-linked-button:last-child, .hotplug-notification-item:last-child {
+  margin-left: 0 !important;
+  margin-right: 6px !important;
+  border-right-width: 0;
+  border-radius: 0 9999px 9999px 0;
+}
+
+.modal-dialog .modal-dialog-linked-button:first-child:last-child, .hotplug-notification-item:first-child:last-child {
+  margin: 0 6px 6px 6px !important;
+  border-right-width: 0;
+  border-radius: 9999px;
+}
+
+.screenshot-ui-show-pointer-button, .screenshot-ui-type-button {
+  border: none;
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:insensitive, .screenshot-ui-type-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: #242424;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:focus, .screenshot-ui-type-button:focus {
+  color: #3281EA;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.screenshot-ui-show-pointer-button:focus:active, .screenshot-ui-type-button:focus:active {
+  color: white;
+}
+
+.screenshot-ui-show-pointer-button:hover, .screenshot-ui-type-button:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:active, .screenshot-ui-type-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.24);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:outlined, .screenshot-ui-type-button:outlined, .screenshot-ui-show-pointer-button:checked, .screenshot-ui-type-button:checked {
+  color: white;
+  background-color: #3281EA;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.workspace-switcher-container, .switcher-list, .resize-popup, .osd-monitor-label, .osd-window {
+  color: white;
+  background-color: #212121;
+  border: none;
+  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.32);
+  padding: 12px;
+}
+
+/* General Typography */
+.message-list .message-list-placeholder {
+  font-weight: 800;
+  font-size: 15pt;
+}
+
+.quick-toggle-menu .header .title {
+  font-weight: 700;
+  font-size: 15pt;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  font-weight: 700;
+  font-size: 13pt;
+}
+
+.background-app-item .title, .message-list-controls {
+  font-weight: 700;
+  font-size: 11pt;
+}
+
+.quick-toggle-menu .header .subtitle, .app-menu .popup-inactive-menu-item:first-child > StLabel {
+  font-weight: 700;
+  font-size: 9pt;
+}
+
+.background-app-item .subtitle, .message .message-header .message-header-content .event-time {
+  font-weight: 400;
+  font-size: 9pt;
+}
+
+/* WIDGETS */
+.shell-link {
+  border-radius: 10px;
+  color: #3281EA;
+  background-color: transparent;
+}
+
+.shell-link:hover {
+  color: #3281EA;
+  background-color: rgba(50, 129, 234, 0.15);
+}
+
+.shell-link:active {
+  color: #3281EA;
+  background-color: rgba(50, 129, 234, 0.3);
+}
+
+.lowres-icon {
+  icon-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.icon-dropshadow {
+  icon-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+}
+
+/* Entries */
+StEntry {
+  min-height: 36px;
+  padding: 0 8px;
+  border-radius: 9999px;
+  border-width: 0;
+  selection-background-color: rgba(50, 129, 234, 0.35) !important;
+  selected-color: #3281EA !important;
+  font-size: 12pt;
+  font-weight: 400;
+  caret-color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.12);
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+StEntry:hover {
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.12) !important;
+}
+
+StEntry:focus {
+  color: white;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #3281EA !important;
+}
+
+StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+StEntry StIcon.capslock-warning {
+  icon-size: 16px;
+  warning-color: #FBC02D;
+  padding: 0 4px;
+}
+
+StEntry StIcon.peek-password {
+  icon-size: 16px;
+  padding: 0 4px;
+}
+
+StEntry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Buttons */
+.icon-button.flat, .background-app-item .flat.close-button, .message .message-header .flat.message-expand-button,
+.message .message-header .flat.message-close-button, .button.flat {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button.flat:focus, .background-app-item .flat.close-button:focus, .message .message-header .flat.message-expand-button:focus,
+.message .message-header .flat.message-close-button:focus, .button.flat:focus {
+  color: white;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.icon-button.flat:hover, .background-app-item .flat.close-button:hover, .message .message-header .flat.message-expand-button:hover,
+.message .message-header .flat.message-close-button:hover, .button.flat:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button.flat:selected, .background-app-item .flat.close-button:selected, .message .message-header .flat.message-expand-button:selected,
+.message .message-header .flat.message-close-button:selected, .button.flat:selected, .icon-button.flat:active, .background-app-item .flat.close-button:active, .message .message-header .flat.message-expand-button:active,
+.message .message-header .flat.message-close-button:active, .button.flat:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button.flat:checked, .background-app-item .flat.close-button:checked, .message .message-header .flat.message-expand-button:checked,
+.message .message-header .flat.message-close-button:checked, .button.flat:checked {
+  color: white;
+  background-color: #3281EA;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button.flat:insensitive, .background-app-item .flat.close-button:insensitive, .message .message-header .flat.message-expand-button:insensitive,
+.message .message-header .flat.message-close-button:insensitive, .button.flat:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.keyboard-brightness-level .button:checked, .icon-button.default, .background-app-item .default.close-button, .message .message-header .default.message-expand-button,
+.message .message-header .default.message-close-button, .button.default {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: #3281EA;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.keyboard-brightness-level .button:focus:checked, .icon-button.default:focus, .background-app-item .default.close-button:focus, .message .message-header .default.message-expand-button:focus,
+.message .message-header .default.message-close-button:focus, .button.default:focus {
+  color: #3281EA;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.keyboard-brightness-level .button:focus:active:checked, .icon-button.default:focus:active, .background-app-item .default.close-button:focus:active, .message .message-header .default.message-expand-button:focus:active,
+.message .message-header .default.message-close-button:focus:active, .button.default:focus:active {
+  color: white;
+}
+
+.keyboard-brightness-level .button:hover:checked, .icon-button.default:hover, .background-app-item .default.close-button:hover, .message .message-header .default.message-expand-button:hover,
+.message .message-header .default.message-close-button:hover, .button.default:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.keyboard-brightness-level .button:insensitive:checked, .icon-button.default:insensitive, .background-app-item .default.close-button:insensitive, .message .message-header .default.message-expand-button:insensitive,
+.message .message-header .default.message-close-button:insensitive, .button.default:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: #3281EA;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.keyboard-brightness-level .button:active:checked, .icon-button.default:active, .background-app-item .default.close-button:active, .message .message-header .default.message-expand-button:active,
+.message .message-header .default.message-close-button:active, .button.default:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.24);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button {
+  min-height: 24px;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 10px;
+  text-align: center;
+  font-size: 10.5pt;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:checked {
+  color: white;
+  background-color: #3281EA;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:focus {
+  color: white;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.icon-button, .background-app-item .close-button, .message .message-header .message-expand-button,
+.message .message-header .message-close-button {
+  min-height: 16px;
+  min-width: 16px;
+  padding: 12px;
+  border-radius: 9999px;
+  border: none;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:hover, .background-app-item .close-button:hover, .message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:active, .background-app-item .close-button:active, .message .message-header .message-expand-button:active,
+.message .message-header .message-close-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:checked, .background-app-item .close-button:checked, .message .message-header .message-expand-button:checked,
+.message .message-header .message-close-button:checked {
+  color: white;
+  background-color: #3281EA;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:insensitive, .background-app-item .close-button:insensitive, .message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:focus, .background-app-item .close-button:focus, .message .message-header .message-expand-button:focus,
+.message .message-header .message-close-button:focus {
+  color: white;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.icon-button StIcon, .background-app-item .close-button StIcon, .message .message-header .message-expand-button StIcon,
+.message .message-header .message-close-button StIcon {
+  icon-size: 16px;
+  -st-icon-style: symbolic;
+}
+
+/* Check Boxes */
+.check-box StBoxLayout {
+  spacing: .8em;
+}
+
+.check-box StBin {
+  width: 24px;
+  height: 24px;
+  padding: 6px;
+  border-radius: 100px;
+  background-image: url("assets/checkbox-off.svg");
+}
+
+.check-box:focus StBin {
+  background-image: url("assets/checkbox-off.svg");
+}
+
+.check-box:hover StBin {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.check-box:active StBin {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.check-box:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:focus:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:hover:checked StBin {
+  background-color: rgba(50, 129, 234, 0.15);
+}
+
+.check-box:active:checked StBin {
+  background-color: rgba(50, 129, 234, 0.3);
+}
+
+/* Switches */
+.toggle-switch {
+  width: 44px;
+  height: 26px;
+  background-size: contain;
+  background-image: url("assets/toggle-off.svg");
+}
+
+.toggle-switch:checked {
+  background-image: url("assets/toggle-on.svg");
+}
+
+.popup-sub-menu .toggle-switch, .quick-toggle-menu .toggle-switch {
+  background-image: url("assets/menu-toggle-off.svg");
+}
+
+.popup-sub-menu .toggle-switch:checked, .quick-toggle-menu .toggle-switch:checked {
+  background-image: url("assets/toggle-on.svg") !important;
+}
+
+/* Slider */
+.slider {
+  height: 22px;
+  -barlevel-height: 2px;
+  -barlevel-background-color: rgba(255, 255, 255, 0.3);
+  -barlevel-border-width: 0;
+  -barlevel-border-color: rgba(255, 255, 255, 0.12);
+  -barlevel-active-background-color: #3281EA;
+  -barlevel-active-border-color: #3b87eb;
+  -barlevel-overdrive-color: #F44336;
+  -barlevel-overdrive-border-color: #f54c40;
+  -barlevel-overdrive-separator-width: 2px;
+  -slider-handle-radius: 7px;
+  -slider-handle-border-width: 0;
+  -slider-handle-border-color: white;
+  color: white;
+}
+
+.slider:hover {
+  color: white;
+}
+
+.slider:active {
+  color: #f2f2f2;
+}
+
+/* Scrollbars */
+StScrollView.vfade {
+  -st-vfade-offset: 32px;
+}
+
+StScrollView.hfade {
+  -st-hfade-offset: 32px;
+}
+
+StScrollBar {
+  padding: 0;
+  margin: 6px;
+}
+
+StScrollView StScrollBar {
+  min-width: 8px;
+  min-height: 8px;
+}
+
+StScrollBar StBin#trough {
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+StScrollBar StButton#vhandle, StScrollBar StButton#hhandle {
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 0.5);
+  border: 4px solid transparent;
+  transition: 500ms all ease;
+}
+
+StScrollBar StButton#vhandle:hover, StScrollBar StButton#hhandle:hover {
+  background-color: rgba(255, 255, 255, 0.7);
+}
+
+StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
+  background-color: white;
+}
+
+#LookingGlassDialog StScrollBar StBin#trough, #overviewGroup StScrollBar StBin#trough {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#LookingGlassDialog StScrollBar StButton#vhandle, #overviewGroup StScrollBar StButton#vhandle, #LookingGlassDialog StScrollBar StButton#hhandle, #overviewGroup StScrollBar StButton#hhandle {
+  background-color: rgba(255, 255, 255, 0.5);
+}
+
+#LookingGlassDialog StScrollBar StButton#vhandle:hover, #overviewGroup StScrollBar StButton#vhandle:hover, #LookingGlassDialog StScrollBar StButton#hhandle:hover, #overviewGroup StScrollBar StButton#hhandle:hover {
+  background-color: rgba(255, 255, 255, 0.7);
+}
+
+#LookingGlassDialog StScrollBar StButton#vhandle:active, #overviewGroup StScrollBar StButton#vhandle:active, #LookingGlassDialog StScrollBar StButton#hhandle:active, #overviewGroup StScrollBar StButton#hhandle:active {
+  background-color: white;
+}
+
+.popup-menu .popup-sub-menu StScrollBar StBin#trough {
+  background-color: rgba(0, 0, 0, 0.15);
+}
+
+.popup-menu .popup-sub-menu StScrollBar StButton#vhandle, .popup-menu .popup-sub-menu StScrollBar StButton#hhandle {
+  background-color: rgba(0, 0, 0, 0.35);
+}
+
+.popup-menu .popup-sub-menu StScrollBar StButton#vhandle:hover, .popup-menu .popup-sub-menu StScrollBar StButton#hhandle:hover {
+  background-color: rgba(0, 0, 0, 0.45);
+}
+
+.popup-menu .popup-sub-menu StScrollBar StButton#vhandle:active, .popup-menu .popup-sub-menu StScrollBar StButton#hhandle:active {
+  background-color: rgba(0, 0, 0, 0.65);
+}
+
+/* Popovers/Menus */
+.popup-menu-boxpointer {
+  -arrow-rise: 6px;
+  background: none;
+}
+
+.popup-menu {
+  min-width: 12em;
+  color: white;
+}
+
+.popup-menu .popup-menu-content {
+  padding: 6px;
+  margin: 0 3px 14px;
+  background-color: rgba(33, 33, 33, 0.97);
+  border-radius: 20px;
+  border: none;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+}
+
+.popup-menu .popup-menu-item {
+  spacing: 6px;
+  padding: 6px 12px;
+  color: white !important;
+  background-color: transparent;
+  transition-duration: 100ms;
+  border-radius: 14px;
+  background-image: none;
+  border: none;
+}
+
+.popup-menu .popup-menu-item:checked {
+  font-weight: normal;
+  border-radius: 14px 14px 0 0;
+  border: none;
+  box-shadow: none;
+  background-color: rgba(255, 255, 255, 0.95) !important;
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-menu-item:checked:hover, .popup-menu .popup-menu-item:checked:focus, .popup-menu .popup-menu-item:checked.selected {
+  background-color: #e5e5e5 !important;
+  color: rgba(0, 0, 0, 0.85) !important;
+}
+
+.popup-menu .popup-menu-item:checked:active {
+  background-color: #dfdfdf !important;
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-menu-item:checked.selected:active {
+  background-color: #e0e0e0 !important;
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-menu-item:checked:insensitive {
+  color: rgba(0, 0, 0, 0.35) !important;
+}
+
+.popup-menu .popup-menu-item:hover, .popup-menu .popup-menu-item:focus, .popup-menu .popup-menu-item.selected {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  color: white !important;
+  transition-duration: 0ms;
+}
+
+.popup-menu .popup-menu-item:active {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+  color: white !important;
+  transition-duration: 150ms;
+}
+
+.popup-menu .popup-menu-item.selected:active {
+  color: white !important;
+}
+
+.popup-menu .popup-menu-item:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+}
+
+.popup-menu .popup-menu-item .toggle-switch:ltr {
+  margin-left: 4px;
+}
+
+.popup-menu .popup-menu-item .toggle-switch:rtl {
+  margin-right: 4px;
+}
+
+.popup-menu .popup-ornamented-menu-item:ltr {
+  padding-left: 6px;
+}
+
+.popup-menu .popup-ornamented-menu-item:rtl {
+  padding-right: 6px;
+}
+
+.popup-menu .popup-inactive-menu-item {
+  color: white !important;
+}
+
+.popup-menu .popup-inactive-menu-item:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+}
+
+.popup-menu .popup-menu-arrow,
+.popup-menu .popup-menu-icon {
+  icon-size: 16px;
+}
+
+.popup-menu .popup-sub-menu {
+  margin: 0;
+  border-radius: 0 0 14px 14px;
+  border: none;
+  box-shadow: none;
+  background-image: none;
+  color: rgba(0, 0, 0, 0.75) !important;
+  background-color: rgba(255, 255, 255, 0.95) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item {
+  margin: 0;
+  border-radius: 14px;
+  background-image: none;
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item:hover, .popup-menu .popup-sub-menu .popup-menu-item:focus, .popup-menu .popup-sub-menu .popup-menu-item.selected {
+  color: rgba(0, 0, 0, 0.85) !important;
+  background-color: rgba(0, 0, 0, 0.15) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item:active {
+  color: rgba(0, 0, 0, 0.85) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item.selected:active {
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.35) !important;
+}
+
+.popup-menu .popup-menu-ornament {
+  icon-size: 1.091em !important;
+  width: 1.091em;
+}
+
+.popup-menu .popup-separator-menu-item {
+  background: none;
+  border: none;
+}
+
+.popup-menu .popup-separator-menu-item .popup-separator-menu-item-separator {
+  height: 1px;
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.popup-sub-menu .popup-menu .popup-separator-menu-item {
+  background-color: transparent;
+}
+
+.popup-sub-menu .popup-menu .popup-separator-menu-item:ltr {
+  margin-right: 2.5em;
+  margin-left: 1.5em;
+}
+
+.popup-sub-menu .popup-menu .popup-separator-menu-item:rtl {
+  margin-left: 2.5em;
+  margin-right: 1.5em;
+}
+
+.popup-sub-menu .popup-menu .popup-separator-menu-item .popup-separator-menu-item-separator {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.popup-menu.panel-menu {
+  margin-bottom: 1.75em;
+}
+
+.background-menu {
+  -boxpointer-gap: 0px;
+  -arrow-rise: 0px;
+}
+
+.app-menu {
+  max-width: 27.25em;
+}
+
+.app-menu .popup-inactive-menu-item:first-child > StLabel:ltr {
+  margin-right: 8px;
+}
+
+.app-menu .popup-inactive-menu-item:first-child > StLabel:rtl {
+  margin-left: 8px;
+}
+
+/* Date/Time Menu */
+#calendarArea {
+  padding: 6px 0 !important;
+}
+
+.calendar {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none;
+  box-shadow: none;
+  background: none;
+  text-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.datemenu-calendar-column {
+  spacing: 6px;
+  border: none;
+  padding: 0 !important;
+  margin: 0 !important;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.datemenu-calendar-column:hover, .datemenu-calendar-column:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.datemenu-calendar-column:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.datemenu-calendar-column:ltr {
+  margin-right: 6px !important;
+  margin-left: 12px !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+  border-left-width: 0;
+}
+
+.datemenu-calendar-column:rtl {
+  margin-left: 6px !important;
+  margin-right: 12px !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+  border-right-width: 0;
+}
+
+.datemenu-calendar-column .datemenu-displays-box {
+  spacing: 6px;
+}
+
+.datemenu-today-button {
+  min-height: 48px;
+  padding: 6px;
+  border-radius: 10px;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  background: none;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.datemenu-today-button .day-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+}
+
+.datemenu-today-button .date-label {
+  font-size: 18pt;
+  font-weight: 400;
+}
+
+.datemenu-today-button:hover, .datemenu-today-button:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.datemenu-today-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.calendar-month-label {
+  height: 20px;
+  margin: 2px;
+  padding: 6px 16px;
+  border-radius: 10px;
+  color: rgba(255, 255, 255, 0.7) !important;
+  background-color: transparent !important;
+  font-weight: bold;
+  text-align: center;
+  text-shadow: none;
+}
+
+.calendar-month-label:focus {
+  color: white !important;
+  background-color: rgba(255, 255, 255, 0.08) !important;
+}
+
+.pager-button {
+  width: 28px !important;
+  height: 28px !important;
+  margin: 2px !important;
+  padding: 2px !important;
+  border-radius: 9999px;
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.pager-button:hover, .pager-button:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.08);
+  box-shadow: none !important;
+}
+
+.pager-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.calendar-change-month-back StIcon,
+.calendar-change-month-forward StIcon {
+  icon-size: 16px;
+}
+
+.calendar-change-month-back {
+  padding: 0 2px;
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-change-month-back:rtl {
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward {
+  padding: 0 2px;
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward:rtl {
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-day {
+  font-size: 9pt;
+  font-weight: 400;
+  text-align: center;
+  width: 3em !important;
+  height: 3em !important;
+  padding: 0 !important;
+  margin: 2px !important;
+  border-radius: 9999px;
+  color: rgba(255, 255, 255, 0.7) !important;
+  border: none !important;
+  font-feature-settings: "tnum";
+  text-shadow: none;
+  background-color: transparent !important;
+}
+
+.calendar-day:hover, .calendar-day:focus {
+  color: white !important;
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  box-shadow: none;
+}
+
+.calendar-day:active {
+  color: white !important;
+  background-color: rgba(255, 255, 255, 0.3) !important;
+  border: none !important;
+}
+
+.calendar-day:selected {
+  color: white !important;
+  background-color: rgba(255, 255, 255, 0.3) !important;
+  border: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.calendar-day.calendar-weekend {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.calendar-day-heading {
+  width: 24px !important;
+  height: 18px !important;
+  margin-top: 2px !important;
+  padding: 6px 0 0 !important;
+  border-radius: 9999px;
+  background-color: transparent !important;
+  color: rgba(255, 255, 255, 0.5) !important;
+  font-size: 9pt;
+  font-weight: 400;
+  font-weight: bold;
+  text-align: center;
+}
+
+.calendar-day {
+  border-width: 0;
+}
+
+.calendar-day-top {
+  border-top-width: 0;
+}
+
+.calendar-day-left {
+  border-left-width: 0;
+}
+
+.calendar-nonwork-day {
+  color: white;
+}
+
+.calendar-today {
+  font-weight: bold !important;
+  color: white !important;
+  background-color: #3281EA !important;
+  border: none;
+}
+
+.calendar-today:hover, .calendar-today:focus {
+  background-color: #408aeb !important;
+  color: white !important;
+}
+
+.calendar-today:active, .calendar-today:selected {
+  background-color: #3281EA !important;
+  color: white !important;
+}
+
+.calendar-today:active:hover, .calendar-today:active:focus, .calendar-today:selected:hover, .calendar-today:selected:focus {
+  background-color: #408aeb !important;
+  color: white !important;
+}
+
+.calendar-day-with-events {
+  color: rgba(255, 255, 255, 0.5);
+  background-image: url("assets/calendar-today.svg");
+  background-size: contain;
+}
+
+.calendar-day-with-events.calendar-work-day {
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: bold;
+}
+
+.calendar-other-month {
+  color: rgba(255, 255, 255, 0.3) !important;
+  font-weight: normal;
+}
+
+.calendar-other-month.calendar-weekend {
+  color: rgba(255, 255, 255, 0.3) !important;
+}
+
+.calendar-week-number {
+  margin: 6px !important;
+  padding: 0 8px !important;
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 0.03);
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 8.25pt;
+  font-weight: bold;
+  text-align: center;
+  text-shadow: none;
+  font-feature-settings: "tnum";
+}
+
+.world-clocks-button,
+.weather-button,
+.events-button,
+.popup-menu .message {
+  padding: 6px 12px;
+  border-radius: 10px;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.world-clocks-button:hover, .world-clocks-button:focus,
+.weather-button:hover,
+.weather-button:focus,
+.events-button:hover,
+.popup-menu .message:hover,
+.events-button:focus,
+.popup-menu .message:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.world-clocks-button:active,
+.weather-button:active,
+.events-button:active,
+.popup-menu .message:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.world-clocks-header,
+.weather-header,
+.message-list-section-title,
+.events-section-title,
+.events-title {
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: bold;
+  margin-bottom: 3px;
+  text-shadow: none;
+}
+
+.weather-grid,
+.world-clocks-grid {
+  spacing-rows: 8px;
+  spacing-columns: 16px;
+}
+
+.world-clocks-header,
+.weather-header,
+.events-section-title {
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: bold;
+  font-size: 1em;
+}
+
+.events-button .events-box, .popup-menu .message .events-box {
+  spacing: 6px;
+}
+
+.events-button .events-list, .popup-menu .message .events-list {
+  color: rgba(255, 255, 255, 0.7);
+  spacing: 12px;
+  text-shadow: none;
+}
+
+.events-button .event-time, .popup-menu .message .event-time {
+  color: rgba(255, 255, 255, 0.3);
+  font-feature-settings: "tnum";
+}
+
+.world-clocks-button .world-clocks-city {
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: normal;
+  font-size: 1em;
+}
+
+.world-clocks-button .world-clocks-time {
+  color: rgba(255, 255, 255, 0.5);
+  font-feature-settings: "tnum";
+  font-weight: bold;
+  font-size: 1em;
+}
+
+.world-clocks-button .world-clocks-time:ltr {
+  text-align: right;
+}
+
+.world-clocks-button .world-clocks-time:rtl {
+  text-align: left;
+}
+
+.world-clocks-button .world-clocks-timezone {
+  color: rgba(255, 255, 255, 0.5);
+  font-feature-settings: "tnum";
+  font-size: 1em;
+}
+
+.weather-button .weather-box {
+  spacing: 12px;
+}
+
+.weather-button .weather-header-box {
+  spacing: 8px;
+}
+
+.weather-button .weather-header.location {
+  font-weight: normal;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.9em;
+}
+
+.weather-button .weather-forecast-icon {
+  icon-size: 32px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.weather-button .weather-forecast-time {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.8em;
+  font-feature-settings: "tnum";
+  font-weight: normal;
+  padding-top: 0.2em;
+  padding-bottom: 0.4em;
+}
+
+.weather-button .weather-forecast-temp {
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.65);
+  text-shadow: none;
+}
+
+/* Message List */
+.message-list {
+  width: 29em;
+  color: rgba(255, 255, 255, 0.7);
+  border: solid transparent;
+}
+
+.message-list:ltr {
+  margin-left: 0;
+  margin-right: 0;
+  padding-right: 0;
+  border-right-width: 0;
+}
+
+.message-list:rtl {
+  margin-right: 0;
+  margin-left: 0;
+  padding-left: 0;
+  border-left-width: 0;
+}
+
+.message-list .message-list-placeholder {
+  color: rgba(255, 255, 255, 0.3);
+}
+
+.message-list .message-list-placeholder > StIcon {
+  icon-size: 96px;
+  margin-bottom: 12px;
+  -st-icon-style: symbolic;
+}
+
+.message-list-sections {
+  spacing: 6px;
+}
+
+.message-list-sections:ltr {
+  margin-right: 4px;
+  padding-left: 6px;
+}
+
+.message-list-sections:rtl {
+  margin-left: 4px;
+  padding-right: 6px;
+}
+
+.message-list-section,
+.message-list-section-list {
+  spacing: 6px;
+}
+
+.message-list-controls {
+  margin: 8px 16px 0;
+  padding: 4px;
+  spacing: 12px;
+}
+
+.message-list-controls .dnd-button {
+  border-width: 2px;
+  border-color: transparent;
+  border-radius: 32px;
+  border-style: solid;
+}
+
+.message-list-controls .dnd-button:focus {
+  border-color: rgba(50, 129, 234, 0.6);
+}
+
+.message {
+  border-radius: 10px;
+  padding: 0;
+  margin: 0;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.32);
+  color: white;
+  background-color: rgba(44, 44, 44, 0.96);
+}
+
+.message:hover, .message:focus, .message:active {
+  background-color: #2C2C2C;
+}
+
+.popup-menu .message {
+  border: 1px solid transparent;
+  border-left: none;
+  border-bottom: none;
+  padding: 0;
+  margin: 0;
+  box-shadow: none;
+  margin: 4px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.message:ltr {
+  padding-right: -2px;
+}
+
+.message:rtl {
+  padding-left: -2px;
+}
+
+.message .message-header {
+  padding: 0 0.409em;
+  margin: 6px;
+  margin-bottom: 0;
+  spacing: 6px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.message .message-header .message-source-icon {
+  icon-size: 1.091em;
+  -st-icon-style: symbolic;
+}
+
+.message .message-header .message-header-content {
+  spacing: 6px;
+  min-height: 1.637em;
+  padding-bottom: 6px;
+}
+
+.message .message-header .message-header-content .message-source-title {
+  font-weight: bold;
+}
+
+.message .message-header .message-header-content .event-time {
+  color: rgba(255, 255, 255, 0.5);
+  padding-bottom: 0.068em;
+}
+
+.message .message-header .message-header-content .event-time:ltr {
+  text-align: right;
+}
+
+.message .message-header .message-header-content .event-time:rtl {
+  text-align: left;
+}
+
+.message .message-header .message-expand-button,
+.message .message-header .message-close-button {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.04);
+  padding: 4px;
+}
+
+.message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.message .message-header .message-expand-button:active, .message .message-header .message-expand-button:active:hover,
+.message .message-header .message-close-button:active,
+.message .message-header .message-close-button:active:hover {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive {
+  background-color: transparent;
+}
+
+.message .message-header .message-expand-button {
+  padding: 4px;
+}
+
+.message .message-header .message-expand-button:ltr {
+  margin-right: 6px;
+}
+
+.message .message-header .message-expand-button:rtl {
+  margin-left: 6px;
+}
+
+.message .message-box {
+  padding: 6px;
+  margin: 6px;
+  margin-top: 0;
+  spacing: 6px;
+}
+
+.message .message-box .message-icon {
+  icon-size: 48px;
+  -st-icon-style: symbolic;
+}
+
+.message .message-box .message-icon:ltr {
+  margin-right: 6px;
+}
+
+.message .message-box .message-icon:rtl {
+  margin-left: 6px;
+}
+
+.message .message-box .message-icon.message-themed-icon {
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 0.12);
+  icon-size: 16px;
+  min-width: 48px;
+  min-height: 48px;
+}
+
+.message .message-box:first-child {
+  margin-top: 12px;
+}
+
+.message .message-box .message-content {
+  spacing: 4px;
+}
+
+.message .message-box .message-content .message-title {
+  font-weight: bold;
+}
+
+.url-highlighter {
+  link-color: #3281EA;
+}
+
+/* Media Controls */
+.message-media-control {
+  margin: 4px 3px !important;
+  padding: 0 12px !important;
+  border-radius: 9999px;
+  color: rgba(255, 255, 255, 0.7);
+  border: none;
+}
+
+.message-media-control:hover, .message-media-control:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.message-media-control:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.message-media-control:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+}
+
+.message-media-control StIcon {
+  icon-size: 16px;
+}
+
+.media-message .message-icon {
+  border-radius: 6px !important;
+}
+
+.media-message .message-icon.message-themed-icon {
+  icon-size: 32px !important;
+}
+
+.candidate-popup-boxpointer {
+  -arrow-border-radius: 2px;
+  -arrow-background-color: transparent;
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 64px;
+  -arrow-rise: 12px;
+}
+
+.candidate-popup-content {
+  background-color: #3C3C3C;
+  border-radius: 11px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+  margin: 3px 10px 13px;
+  padding: 6px;
+  spacing: 6px;
+  border: none;
+}
+
+.candidate-index {
+  padding: 0 0.5em 0 0;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.candidate-box:selected .candidate-index {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.candidate-box {
+  padding: 0.3em 0.5em 0.3em 0.5em;
+  margin-right: 3px;
+  border-radius: 5px;
+}
+
+.candidate-box:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+  color: white;
+}
+
+.candidate-box:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: white;
+}
+
+.candidate-box:selected {
+  background-color: #3281EA;
+  color: white;
+}
+
+.candidate-box:last-child {
+  margin-right: 0;
+}
+
+.candidate-page-button-box {
+  height: 2em;
+}
+
+.vertical .candidate-page-button-box {
+  padding-top: 0.5em;
+}
+
+.horizontal .candidate-page-button-box {
+  padding-left: 0.5em;
+}
+
+.candidate-page-button {
+  padding: 4px 8px;
+}
+
+.candidate-page-button-previous {
+  border-radius: 5px;
+  border-right-width: 0;
+}
+
+.candidate-page-button-next {
+  border-radius: 5px;
+  margin-left: 2px;
+}
+
+.candidate-page-button-icon {
+  icon-size: 1em;
+}
+
+.quick-settings {
+  padding: 18px !important;
+  border-radius: 38px !important;
+  margin-top: 3px !important;
+  border: none;
+}
+
+.quick-settings .icon-button, .quick-settings .background-app-item .close-button, .background-app-item .quick-settings .close-button, .quick-settings .message .message-header .message-expand-button, .message .message-header .quick-settings .message-expand-button,
+.quick-settings .message .message-header .message-close-button,
+.message .message-header .quick-settings .message-close-button, .quick-settings .button {
+  padding: 12px;
+}
+
+.quick-settings .icon-button > StIcon, .quick-settings .background-app-item .close-button > StIcon, .background-app-item .quick-settings .close-button > StIcon, .quick-settings .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings .message-expand-button > StIcon,
+.quick-settings .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings .message-close-button > StIcon, .quick-settings .button > StIcon {
+  icon-size: 16px;
+}
+
+.quick-settings-grid {
+  spacing-rows: 12px;
+  spacing-columns: 12px;
+}
+
+.quick-toggle, .quick-menu-toggle {
+  border-radius: 9999px;
+  min-width: 12em;
+  max-width: 12em;
+  min-height: 44px;
+  border: none;
+}
+
+.quick-toggle {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+  /* Move padding into the box; this is to allow menu arrows
+     to extend to the border */
+}
+
+.quick-toggle:hover {
+  background-color: rgba(255, 255, 255, 0.12) !important;
+}
+
+.quick-toggle:active {
+  background-color: rgba(255, 255, 255, 0.24) !important;
+}
+
+.quick-toggle:checked {
+  background-color: #3281EA !important;
+  color: white !important;
+}
+
+.quick-toggle:checked:hover {
+  background-color: #478eec !important;
+  color: white !important;
+}
+
+.quick-toggle:checked:active {
+  background-color: #5b9aee !important;
+  color: white !important;
+}
+
+.quick-toggle > StBoxLayout {
+  spacing: 6px;
+}
+
+.quick-toggle.button {
+  padding: 0;
+}
+
+.quick-toggle > StBoxLayout {
+  padding: 0 12px;
+}
+
+.quick-toggle:ltr > StBoxLayout {
+  padding-left: 15px;
+}
+
+.quick-toggle:rtl > StBoxLayout {
+  padding-right: 15px;
+}
+
+.quick-toggle .quick-toggle-title {
+  font-weight: bold;
+}
+
+.quick-toggle StBoxLayout > .quick-toggle-subtitle {
+  font-weight: normal;
+  font-size: 12px;
+}
+
+.quick-toggle .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-menu-toggle .quick-toggle {
+  min-width: auto;
+  max-width: auto;
+}
+
+.quick-menu-toggle .quick-toggle:ltr {
+  border-radius: 9999px 0 0 9999px;
+}
+
+.quick-menu-toggle .quick-toggle:ltr > StBoxLayout {
+  padding-right: 0;
+}
+
+.quick-menu-toggle .quick-toggle:rtl {
+  border-radius: 0 9999px 9999px 0;
+}
+
+.quick-menu-toggle .quick-toggle:rtr > StBoxLayout {
+  padding-left: 0;
+}
+
+.quick-menu-toggle .quick-toggle:ltr:last-child {
+  border-radius: 9999px;
+}
+
+.quick-menu-toggle .quick-toggle:rtl:last-child {
+  border-radius: 9999px;
+}
+
+.quick-menu-toggle .quick-toggle-arrow {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  padding: 6px 10.5px;
+  border: none !important;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:hover {
+  background-color: rgba(255, 255, 255, 0.12) !important;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:active {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:checked {
+  background-color: #3281EA !important;
+  color: white;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:checked:hover {
+  background-color: #478eec !important;
+  color: white;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:checked:active {
+  background-color: #5b9aee !important;
+  color: white;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:ltr {
+  border-radius: 0 9999px 9999px 0;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:rtl {
+  border-radius: 9999px 0 0 9999px;
+}
+
+.quick-slider > StBoxLayout {
+  spacing: 6px;
+}
+
+.quick-slider .icon-button, .quick-slider .background-app-item .close-button, .background-app-item .quick-slider .close-button, .quick-slider .message .message-header .message-expand-button, .message .message-header .quick-slider .message-expand-button,
+.quick-slider .message .message-header .message-close-button,
+.message .message-header .quick-slider .message-close-button {
+  padding: 9px;
+}
+
+.quick-slider .slider-bin {
+  min-height: 16px;
+  padding: 6px;
+  border-radius: 9999px;
+}
+
+.quick-slider .slider-bin:focus {
+  color: #3281EA;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.quick-slider .slider-bin:focus:active {
+  color: white;
+}
+
+.quick-slider .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-toggle-menu {
+  border-radius: 30px !important;
+  padding: 12px;
+  margin: 12px 21px 0;
+  background-color: white !important;
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+.quick-toggle-menu:insensitive {
+  background-color: white !important;
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+.quick-toggle-menu .popup-menu-item {
+  padding: 8px !important;
+  border-radius: 9999px !important;
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+.quick-toggle-menu .popup-menu-item StLabel {
+  color: rgba(0, 0, 0, 0.65);
+}
+
+.quick-toggle-menu .popup-menu-item:focus, .quick-toggle-menu .popup-menu-item:hover, .quick-toggle-menu .popup-menu-item.selected {
+  color: rgba(0, 0, 0, 0.75) !important;
+  background-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.quick-toggle-menu .popup-menu-item:active {
+  color: rgba(0, 0, 0, 0.75) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+
+.quick-toggle-menu .popup-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.25) !important;
+}
+
+.quick-toggle-menu .popup-menu-item > StIcon {
+  -st-icon-style: symbolic;
+  icon-size: 1.091em;
+}
+
+.quick-toggle-menu .popup-menu-item > :first-child:ltr {
+  padding-left: 10px !important;
+}
+
+.quick-toggle-menu .popup-menu-item > :first-child:rtl {
+  padding-right: 10px !important;
+}
+
+.quick-toggle-menu .popup-menu-item .popup-separator-menu-item-separator {
+  margin: 6px 18px 6px 0 !important;
+  padding: 0 !important;
+  background-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.quick-toggle-menu .popup-menu-item .toggle-switch {
+  background-image: url("assets/menu-toggle-off.svg");
+}
+
+.quick-toggle-menu .header {
+  spacing-rows: 3px;
+  spacing-columns: 12px;
+  padding-bottom: 12px;
+}
+
+.quick-toggle-menu .header .icon {
+  icon-size: 24px;
+  border-radius: 9999px;
+  padding: 9px;
+  background-color: rgba(0, 0, 0, 0.08) !important;
+}
+
+.quick-toggle-menu .header .icon.active {
+  background-color: #3281EA !important;
+  color: white !important;
+}
+
+.quick-settings-system-item > StBoxLayout {
+  spacing: 12px;
+}
+
+.quick-settings-system-item .icon-button, .quick-settings-system-item .background-app-item .close-button, .background-app-item .quick-settings-system-item .close-button, .quick-settings-system-item .message .message-header .message-expand-button, .message .message-header .quick-settings-system-item .message-expand-button,
+.quick-settings-system-item .message .message-header .message-close-button,
+.message .message-header .quick-settings-system-item .message-close-button {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.quick-settings-system-item .icon-button:hover, .quick-settings-system-item .background-app-item .close-button:hover, .background-app-item .quick-settings-system-item .close-button:hover, .quick-settings-system-item .message .message-header .message-expand-button:hover, .message .message-header .quick-settings-system-item .message-expand-button:hover,
+.quick-settings-system-item .message .message-header .message-close-button:hover,
+.message .message-header .quick-settings-system-item .message-close-button:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.quick-settings-system-item .icon-button:active, .quick-settings-system-item .background-app-item .close-button:active, .background-app-item .quick-settings-system-item .close-button:active, .quick-settings-system-item .message .message-header .message-expand-button:active, .message .message-header .quick-settings-system-item .message-expand-button:active,
+.quick-settings-system-item .message .message-header .message-close-button:active,
+.message .message-header .quick-settings-system-item .message-close-button:active {
+  background-color: rgba(255, 255, 255, 0.24);
+}
+
+.quick-settings-system-item .icon-button > StIcon, .quick-settings-system-item .background-app-item .close-button > StIcon, .background-app-item .quick-settings-system-item .close-button > StIcon, .quick-settings-system-item .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings-system-item .message-expand-button > StIcon,
+.quick-settings-system-item .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings-system-item .message-close-button > StIcon {
+  -st-icon-style: symbolic;
+}
+
+.quick-settings-system-item .power-item {
+  min-height: 0;
+  min-width: 0;
+}
+
+.quick-settings-system-item .power-item:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.04);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+  background-color: transparent;
+}
+
+.nm-network-item .wireless-secure-icon {
+  icon-size: 8px;
+}
+
+.bt-device-item .popup-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  text-align: center;
+  padding: 2em 4em;
+}
+
+.device-subtitle {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.keyboard-brightness-level {
+  spacing: 6px;
+  background-color: #3C3C3C !important;
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+.background-apps-quick-toggle {
+  min-height: 44px;
+  background-color: transparent;
+}
+
+.background-apps-quick-toggle StIcon {
+  icon-size: 16px !important;
+}
+
+.background-app-item .popup-menu-icon {
+  icon-size: 32px !important;
+  -st-icon-style: regular !important;
+}
+
+.background-app-item .close-button {
+  padding: 6px;
+}
+
+.background-app-item.popup-inactive-menu-item {
+  color: white;
+}
+
+/* Notifications & Message Tray */
+.notification-banner {
+  min-height: 64px;
+  width: 34em;
+  font-size: 1em;
+  margin: 6px;
+  border-radius: 20px;
+  border-left: none;
+  border-bottom: none;
+}
+
+.notification-buttons-bin {
+  background-color: transparent;
+  padding: 0;
+  spacing: 0;
+  margin: 0;
+}
+
+.notification-button {
+  min-height: 40px;
+  padding: 3px 16px;
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.7);
+  font-weight: 500;
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.popup-menu .notification-button {
+  padding: 0 16px;
+}
+
+.notification-button:first-child:ltr {
+  border-radius: 0 0 0 20px;
+}
+
+.notification-button:last-child:ltr {
+  border-radius: 0 0 20px;
+  margin-right: 0 !important;
+}
+
+.notification-button:first-child:rtl {
+  border-radius: 0 0 20px;
+}
+
+.notification-button:last-child:rtl {
+  border-radius: 0 0 0 20px;
+  margin-left: 0 !important;
+}
+
+.notification-button:first-child:last-child {
+  border-radius: 0 0 20px 20px;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.notification-button:focus {
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.7);
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.08);
+}
+
+.notification-button:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+  color: white;
+  box-shadow: none;
+}
+
+.notification-button:active, .notification-button:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: white;
+}
+
+.notification-button:insensitive {
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.3);
+}
+
+.popup-menu .notification-button:first-child:ltr {
+  border-radius: 0 0 0 10px;
+}
+
+.popup-menu .notification-button:last-child:ltr {
+  border-radius: 0 0 10px;
+}
+
+.popup-menu .notification-button:first-child:rtl {
+  border-radius: 0 0 10px;
+}
+
+.popup-menu .notification-button:last-child:rtl {
+  border-radius: 0 0 0 10px;
+}
+
+.popup-menu .notification-button:first-child:last-child {
+  border-radius: 0 0 10px 10px;
+}
+
+.hotplug-notification-item {
+  padding: 2px 10px;
+}
+
+.hotplug-notification-item-icon {
+  icon-size: 24px;
+  padding: 0 4px;
+}
+
+/* Modal Dialogs */
+.headline {
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.modal-dialog {
+  border-radius: 26px;
+  color: white;
+  background-color: #2C2C2C;
+  border: 0 none rgba(0, 0, 0, 0.75);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+}
+
+.modal-dialog .modal-dialog-content-box {
+  margin: 32px 40px;
+  spacing: 32px;
+  max-width: 28em;
+  background-color: #2C2C2C;
+}
+
+.modal-dialog .modal-dialog-linked-button {
+  min-height: 40px;
+  padding: 0 16px;
+}
+
+/* End Session Dialog */
+.end-session-dialog {
+  width: 30em;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child {
+  color: white !important;
+  background-color: #F44336;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:hover {
+  color: white !important;
+  background-color: #f66c62;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:active {
+  color: white !important;
+  background-color: #f32c1e;
+}
+
+.end-session-dialog .end-session-dialog-battery-warning,
+.end-session-dialog .dialog-list-title {
+  color: #FBC02D;
+}
+
+/* Message Dialog */
+.message-dialog-content {
+  spacing: 18px;
+}
+
+.message-dialog-content .message-dialog-title {
+  text-align: center;
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-title.lightweight {
+  font-size: 13pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-description {
+  text-align: center;
+}
+
+/* Dialog List */
+.dialog-list {
+  spacing: 18px;
+}
+
+.dialog-list .dialog-list-title {
+  text-align: center;
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-scrollview {
+  max-height: 200px;
+}
+
+.dialog-list .dialog-list-box {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-title {
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-description {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+/* Run Dialog */
+.run-dialog .modal-dialog-content-box {
+  margin-top: 24px;
+  margin-bottom: 14px;
+}
+
+.run-dialog .run-dialog-entry {
+  width: 20em;
+}
+
+.run-dialog .run-dialog-description {
+  font-size: 12pt;
+  font-weight: 400;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Password or Authentication Dialog */
+.prompt-dialog {
+  width: 28em;
+}
+
+.prompt-dialog .modal-dialog-linked-button:first-child {
+  color: #F44336;
+}
+
+.prompt-dialog .modal-dialog-linked-button:first-child:active {
+  color: white !important;
+  background-color: #F44336;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child {
+  color: white !important;
+  background-color: #3281EA;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:hover {
+  color: white !important;
+  background-color: #5c9bee;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:active {
+  color: white !important;
+  background-color: #1b73e8;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:insensitive {
+  color: rgba(50, 129, 234, 0.5) !important;
+  background-color: rgba(50, 129, 234, 0.15);
+}
+
+.prompt-dialog .modal-dialog-content-box {
+  margin-bottom: 24px;
+  background-color: #2C2C2C;
+}
+
+.prompt-dialog-password-grid {
+  spacing-rows: 8px;
+  spacing-columns: 4px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry {
+  width: auto;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:ltr {
+  margin-left: 20px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:rtl {
+  margin-right: 20px;
+}
+
+.prompt-dialog-password-layout {
+  spacing: 8px;
+}
+
+.prompt-dialog-password-entry {
+  width: 20em;
+}
+
+.prompt-dialog-error-label,
+.prompt-dialog-info-label,
+.prompt-dialog-null-label {
+  text-align: center;
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.prompt-dialog-error-label {
+  color: #FBC02D;
+}
+
+/* Polkit Dialog */
+.polkit-dialog-user-layout {
+  text-align: center;
+  spacing: 8px;
+  margin-bottom: 6px;
+}
+
+.polkit-dialog-user-layout .polkit-dialog-user-root-label {
+  color: #FBC02D;
+}
+
+/* Audio selection dialog */
+.audio-device-selection-dialog .modal-dialog-content-box {
+  margin-bottom: 28px;
+}
+
+.audio-device-selection-dialog .audio-selection-box {
+  spacing: 20px;
+}
+
+.audio-selection-device {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+}
+
+.audio-selection-device:active, .audio-selection-device:hover, .audio-selection-device:focus {
+  background-color: #3281EA;
+}
+
+.audio-selection-device-box {
+  padding: 20px;
+  spacing: 20px;
+}
+
+.audio-selection-device-icon {
+  icon-size: 64px;
+}
+
+/* Welcome dialog */
+.welcome-dialog-image {
+  background-image: url("resource:///org/gnome/shell/theme/gnome-shell-start.svg");
+  background-size: contain;
+  /* Reasonable maximum dimensions */
+  height: 300px;
+  width: 300px;
+}
+
+/* Network Dialogs */
+.nm-dialog {
+  max-height: 34em;
+  min-height: 31em;
+  min-width: 32em;
+}
+
+.nm-dialog-content {
+  spacing: 20px;
+  padding: 24px;
+}
+
+.nm-dialog-airplane-box {
+  spacing: 12px;
+}
+
+.nm-dialog-airplane-headline {
+  font-weight: bold;
+  text-align: center;
+}
+
+.nm-dialog-airplane-text {
+  color: white;
+}
+
+.nm-dialog-header {
+  font-weight: bold;
+}
+
+.nm-dialog-header-icon {
+  icon-size: 32px;
+}
+
+.nm-dialog-header-hbox {
+  spacing: 10px;
+}
+
+.nm-dialog-scroll-view {
+  border: none;
+  background-color: rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 12px;
+  padding-right: 0;
+}
+
+.nm-dialog-item {
+  font-size: 1em;
+  border-bottom: none;
+  border-radius: 4px;
+  padding: 12px;
+  spacing: 0px;
+}
+
+.nm-dialog-item:hover, .nm-dialog-item:focus {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.nm-dialog-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.nm-dialog-item:selected {
+  background-color: #3281EA;
+  color: white;
+}
+
+.nm-dialog-icon {
+  icon-size: 16px;
+}
+
+.nm-dialog-icons {
+  spacing: 12px;
+}
+
+.no-networks-label {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.no-networks-box {
+  spacing: 6px;
+}
+
+/* OSD */
+.osd-window {
+  text-align: center;
+  font-weight: bold;
+  spacing: 12px;
+  padding: 12px 18px;
+  margin-bottom: 8em;
+  border-radius: 9999px;
+}
+
+.osd-window > * {
+  spacing: 8px;
+}
+
+.osd-window StIcon {
+  icon-size: 32px;
+}
+
+.osd-window .osd-monitor-label {
+  font-size: 3em;
+}
+
+.osd-window StLabel:ltr {
+  margin-right: 6px;
+}
+
+.osd-window StLabel:rtl {
+  margin-left: 6px;
+}
+
+.osd-window .level {
+  height: 4px;
+  min-width: 160px;
+  margin-bottom: 4px;
+  -barlevel-height: 4px;
+  -barlevel-background-color: rgba(50, 129, 234, 0.3);
+  -barlevel-active-background-color: #3281EA;
+  -barlevel-overdrive-color: #F44336;
+  -barlevel-overdrive-separator-width: 3px;
+  -barlevel-border-width: 0;
+}
+
+.osd-window .level:first-child {
+  margin-bottom: 0px;
+}
+
+.osd-window .level:ltr {
+  margin-right: 6px;
+}
+
+.osd-window .level:rtl {
+  margin-left: 6px;
+}
+
+.osd-monitor-label {
+  border-radius: 18px;
+  font-size: 3em;
+  font-weight: bold;
+  margin: 12px;
+  text-align: center;
+  min-width: 1.3em;
+}
+
+/* Pad OSD */
+.pad-osd-window {
+  padding: 32px;
+  background-color: rgba(0, 0, 0, 0.8);
+  border: none;
+}
+
+.pad-osd-window .pad-osd-title-box {
+  spacing: 12px;
+}
+
+.pad-osd-window .pad-osd-title-menu-box {
+  spacing: 6px;
+}
+
+.combo-box-label {
+  width: 15em;
+}
+
+.resize-popup {
+  border-radius: 18px;
+}
+
+/* App Switcher */
+.switcher-popup {
+  padding: 8px;
+  spacing: 24px;
+}
+
+.switcher-list {
+  border-radius: 22px;
+}
+
+.switcher-list .item-box {
+  padding: 8px;
+  border-radius: 10px;
+  border: none;
+  background-color: transparent;
+  color: white;
+}
+
+.switcher-list .item-box:outlined {
+  background-color: rgba(255, 255, 255, 0.08);
+  color: white;
+}
+
+.switcher-list .item-box:selected {
+  background-color: #3281EA;
+  color: white;
+}
+
+.switcher-list .thumbnail-box {
+  padding: 2px;
+  spacing: 6px;
+}
+
+.switcher-list .thumbnail {
+  width: 256px;
+}
+
+.switcher-list .separator {
+  width: 1px;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.switcher-list .switcher-list-item-container {
+  spacing: 12px;
+}
+
+.switcher-arrow {
+  border-color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.switcher-arrow:highlighted {
+  color: white;
+}
+
+.input-source-switcher-symbol {
+  font-size: 34pt;
+  width: 96px;
+  height: 96px;
+}
+
+.cycler-highlight {
+  border: 5px solid #3281EA;
+}
+
+/* Workspace Switcher */
+.workspace-switcher-group {
+  padding: 12px;
+}
+
+.workspace-switcher-container {
+  border-radius: 18px;
+}
+
+.workspace-switcher {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  spacing: 12px;
+}
+
+.ws-switcher-box {
+  height: 50px;
+  background-size: 32px;
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+}
+
+.ws-switcher-active-up,
+.ws-switcher-active-down,
+.ws-switcher-active-left,
+.ws-switcher-active-right {
+  height: 52px;
+  background-color: #3281EA;
+  border: none;
+  border-radius: 13px;
+  color: white;
+}
+
+/* Top Bar */
+#panel {
+  font-weight: bold;
+  font-feature-settings: "tnum";
+  padding: 0 !important;
+  transition-duration: 250ms;
+  height: 38px;
+  border: none;
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.65);
+  margin: 3px;
+  border-radius: 9999px;
+}
+
+#panel.unlock-screen, #panel.login-screen, #panel:overview {
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-corner, #panel.login-screen .panel-corner, #panel:overview .panel-corner {
+  -panel-corner-opacity: 0;
+}
+
+#panel .panel-corner {
+  -panel-corner-radius: 0;
+  -panel-corner-background-color: rgba(33, 33, 33, 0.65);
+  -panel-corner-border-width: 0;
+  -panel-corner-border-color: transparent;
+  -panel-corner-opacity: 1;
+  transition-duration: 250ms;
+}
+
+#panel .panel-button#panelActivities {
+  -natural-hpadding: 15px;
+}
+
+#panel .panel-button#panelActivities StBoxLayout {
+  spacing: 6px;
+}
+
+#panel .panel-button#panelActivities .workspace-dot {
+  border-radius: 9999px;
+  min-width: 8px;
+  min-height: 8px;
+  background-color: white;
+}
+
+#panel .panel-button {
+  font-weight: bold;
+  color: white;
+  -natural-hpadding: 11px;
+  -minimum-hpadding: 11px;
+  transition-duration: 150ms;
+  border: 3px solid transparent;
+  border-radius: 9999px;
+  margin: 0;
+}
+
+#panel .panel-button.clock-display {
+  -natural-hpadding: 0 !important;
+  -minimum-hpadding: 0 !important;
+  padding: 0 !important;
+  spacing: 0 !important;
+}
+
+#panel .panel-button.clock-display .clock-display-box {
+  spacing: 0;
+}
+
+#panel .panel-button.clock-display .clock {
+  border-radius: 9999px;
+  padding: 0 12px !important;
+}
+
+#panel .panel-button:hover {
+  background-color: transparent;
+  box-shadow: inset 0 0 0 1000px rgba(255, 255, 255, 0.12);
+}
+
+#panel .panel-button:hover.clock-display {
+  box-shadow: none;
+  background-color: transparent;
+}
+
+#panel .panel-button:hover.clock-display .clock {
+  box-shadow: inset 0 0 0 1000px rgba(255, 255, 255, 0.12);
+}
+
+#panel .panel-button:active, #panel .panel-button:overview, #panel .panel-button:focus, #panel .panel-button:checked {
+  background-color: transparent;
+  box-shadow: inset 0 0 0 1000px rgba(255, 255, 255, 0.3);
+}
+
+#panel .panel-button:active.clock-display, #panel .panel-button:overview.clock-display, #panel .panel-button:focus.clock-display, #panel .panel-button:checked.clock-display {
+  box-shadow: none;
+  background-color: transparent;
+}
+
+#panel .panel-button:active.clock-display .clock, #panel .panel-button:overview.clock-display .clock, #panel .panel-button:focus.clock-display .clock, #panel .panel-button:checked.clock-display .clock {
+  box-shadow: inset 0 0 0 1000px rgba(255, 255, 255, 0.3);
+}
+
+#panel .panel-button .system-status-icon {
+  icon-size: 16px;
+  padding: 6px;
+  margin: 0;
+}
+
+#panel .panel-button .appindicator-trayicons-box {
+  margin: 0 6px;
+}
+
+#panel .panel-button .app-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button {
+  border: 0 none transparent !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  -natural-hpadding: 3px !important;
+  -minimum-hpadding: 3px !important;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .panel-status-menu-box,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .panel-status-menu-box,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .panel-status-menu-box {
+  spacing: 0;
+  padding: 0;
+  margin: 0;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon {
+  border-radius: 9999px;
+  width: 33px;
+  margin: 3px 0;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:hover,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  box-shadow: none;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:active, #panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:overview, #panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:focus, #panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:checked,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:active,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:overview,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:focus,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: none;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button {
+  border-radius: 9999px;
+  width: 33px;
+  margin: 3px 0;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  box-shadow: none;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:active, #panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:overview, #panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:focus, #panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: none;
+}
+
+#panel Gjs_status_keyboard_InputSourceIndicator.panel-button,
+#panel Gjs_appindicatorsupport_rgcjonas_gmail_com_indicatorStatusIcon_IndicatorStatusIcon.panel-button,
+#panel Gjs_appindicatorsupport_rgcjonas_gmail_com_indicatorStatusIcon_AppIndicatorsIndicatorStatusIcon.panel-button {
+  -natural-hpadding: 17px !important;
+  -minimum-hpadding: 17px !important;
+}
+
+#panel .screencast-indicator,
+#panel .remote-access-indicator {
+  color: #FBC02D;
+}
+
+#appMenu {
+  spacing: 6px;
+}
+
+#appMenu .label-shadow {
+  color: transparent;
+}
+
+#appMenu .panel-status-menu-box {
+  padding: 0 6px;
+  spacing: 6px;
+}
+
+/* Activities Ripple */
+.ripple-box {
+  background-color: rgba(50, 129, 234, 0.35);
+  width: 52px;
+  height: 52px;
+  border-radius: 0 0 52px 0;
+}
+
+.ripple-box:rtl {
+  border-radius: 0 0 0 52px;
+}
+
+/* OVERVIEW */
+.controls-manager, .secondary-monitor-workspaces {
+  spacing: 12px;
+}
+
+#overviewGroup {
+  background-color: #242424;
+}
+
+.overview-controls {
+  padding-bottom: 32px;
+}
+
+/* Window Picker */
+.window-picker {
+  spacing: 6px;
+}
+
+.window-caption {
+  color: white;
+  background-color: rgba(25, 25, 25, 0.9);
+  border-radius: 9999px;
+  padding: 6px 12px;
+  box-shadow: none;
+  border: none;
+}
+
+.window-close, .screenshot-ui-close-button {
+  background-color: #242424;
+  color: white;
+  border-radius: 9999px;
+  padding: 3px;
+  height: 30px;
+  width: 30px;
+  box-shadow: -1px 1px 5px 0px rgba(0, 0, 0, 0.5);
+  transition-duration: 300ms;
+}
+
+.window-close StIcon, .screenshot-ui-close-button StIcon {
+  icon-size: 24px;
+}
+
+.window-close:hover, .screenshot-ui-close-button:hover {
+  background-color: #4a4a4a;
+}
+
+.window-close:active, .screenshot-ui-close-button:active {
+  color: rgba(255, 255, 255, 0.8);
+  background-color: #171717;
+}
+
+.workspace-background {
+  border-radius: 30px;
+  background-color: #242424;
+  box-shadow: 0 4px 16px 4px rgba(0, 0, 0, 0.15);
+}
+
+.search-entry {
+  min-height: 24px;
+  padding: 6px 6px;
+  width: 320px;
+  border-radius: 9999px;
+  selection-background-color: #3281EA;
+  selected-color: white !important;
+  caret-color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.12);
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.search-entry:hover {
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.12) !important;
+}
+
+.search-entry:focus {
+  color: white;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #3281EA !important;
+}
+
+.search-entry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.search-entry .search-entry-icon {
+  icon-size: 16px;
+  padding: 0 4px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.search-entry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+#overview .search-entry {
+  margin-top: 12px;
+  margin-bottom: 6px;
+  border: none !important;
+  caret-color: rgba(0, 0, 0, 0.75);
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.75);
+  border-color: transparent !important;
+  box-shadow: none !important;
+}
+
+#overview .search-entry:hover {
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.85);
+  box-shadow: none !important;
+}
+
+#overview .search-entry:focus {
+  color: rgba(0, 0, 0, 0.85);
+  border-color: transparent;
+  background-color: rgba(255, 255, 255, 0.95);
+  border: none !important;
+  box-shadow: none !important;
+  selection-background-color: #3281EA;
+  selected-color: white !important;
+}
+
+#overview .search-entry .search-entry-icon {
+  color: rgba(0, 0, 0, 0.65);
+}
+
+#overview .search-entry:hover .search-entry-icon, #overview .search-entry:focus .search-entry-icon {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+#overview .search-entry StLabel.hint-text {
+  color: rgba(0, 0, 0, 0.35);
+}
+
+/* Search */
+#searchResults {
+  margin: 0 4px;
+}
+
+#searchResultsContent {
+  max-width: 1044px;
+}
+
+.search-section {
+  spacing: 12px;
+}
+
+.search-section .search-section-separator {
+  height: 8px;
+  background-color: transparent;
+}
+
+.search-section-content {
+  background-color: rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  color: white;
+  padding: 12px;
+  margin: 0 12px;
+}
+
+.list-search-result, .search-provider-icon {
+  border-radius: 10px;
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.list-search-result:focus, .search-provider-icon:focus, .list-search-result:hover, .search-provider-icon:hover, .list-search-result:selected, .search-provider-icon:selected {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  transition-duration: 200ms;
+  border-radius: 10px;
+}
+
+.list-search-result:active, .search-provider-icon:active, .list-search-result:checked, .search-provider-icon:checked {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-radius: 10px;
+}
+
+.search-statustext {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.grid-search-results {
+  spacing: 30px;
+  margin: 0 12px;
+}
+
+.search-provider-icon:ltr {
+  margin-right: 4px;
+}
+
+.search-provider-icon:rtl {
+  margin-left: 4px;
+}
+
+.search-provider-icon .list-search-provider-content {
+  spacing: 12px;
+}
+
+.search-provider-icon .list-search-provider-content .list-search-provider-details {
+  width: 120px;
+  margin-top: 0;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.list-search-results {
+  spacing: 6px;
+}
+
+.list-search-result .list-search-result-content {
+  spacing: 6px;
+}
+
+.list-search-result .list-search-result-title {
+  spacing: 12px;
+}
+
+.list-search-result .list-search-result-description {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Dash */
+#dash {
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+#dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 9999px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+#dash .dash-item-container .placeholder {
+  background-image: none;
+  background-size: contain;
+  height: 32px;
+}
+
+#dash .dash-item-container .empty-dash-drop-target {
+  width: 32px;
+  height: 32px;
+}
+
+#dash .dash-item-container .show-apps,
+#dash .dash-item-container .overview-tile,
+#dash .dash-item-container .grid-search-result {
+  background: none;
+  box-shadow: none;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  margin: 0 2px;
+  padding-bottom: 12px;
+}
+
+#dash .dash-item-container .show-apps .overview-icon,
+#dash .dash-item-container .overview-tile .overview-icon,
+#dash .dash-item-container .grid-search-result .overview-icon {
+  border-radius: 9999px;
+  padding: 6px;
+  spacing: 6px;
+  text-align: center;
+  transition-duration: 100ms;
+  background-color: transparent;
+  color: white;
+}
+
+#dash .dash-item-container .show-apps:focus .overview-icon,
+#dash .dash-item-container .overview-tile:focus .overview-icon,
+#dash .dash-item-container .grid-search-result:focus .overview-icon {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#dash .dash-item-container .show-apps:hover .overview-icon,
+#dash .dash-item-container .overview-tile:hover .overview-icon,
+#dash .dash-item-container .grid-search-result:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#dash .dash-item-container .show-apps:active .overview-icon,
+#dash .dash-item-container .overview-tile:active .overview-icon,
+#dash .dash-item-container .grid-search-result:active .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#dash .dash-item-container .show-apps:checked .overview-icon,
+#dash .dash-item-container .overview-tile:checked .overview-icon,
+#dash .dash-item-container .grid-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#dash .dash-item-container .app-grid-running-dot {
+  offset-y: -12px;
+}
+
+#dash .dash-separator {
+  width: 1px;
+  margin-left: 4px;
+  margin-right: 4px;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-separator,
+#dash .dash-background {
+  margin-bottom: 12px;
+}
+
+.dash-label {
+  border-radius: 9999px;
+  padding: 6px 12px;
+  margin: 9px;
+  color: white;
+  background-color: rgba(0, 0, 0, 0.75);
+  border: none;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.32);
+  text-align: center;
+  -y-offset: 0;
+  -x-offset: 0;
+}
+
+/* App Grid */
+.icon-grid {
+  row-spacing: 12px;
+  column-spacing: 12px;
+  max-row-spacing: 36px;
+  max-column-spacing: 36px;
+  page-padding-top: 24px;
+  page-padding-bottom: 24px;
+  page-padding-left: 18px;
+  page-padding-right: 18px;
+}
+
+/* App Icons */
+.overview-tile, .grid-search-result {
+  border-radius: 20px;
+  padding: 12px;
+  spacing: 6px;
+  transition-duration: 150ms;
+  text-align: center;
+  background-color: transparent;
+  color: white;
+  border: 1px solid transparent;
+  box-shadow: inset 0 1px transparent;
+}
+
+.overview-tile:hover, .grid-search-result:hover, .overview-tile:focus, .grid-search-result:focus, .overview-tile:highlighted, .grid-search-result:highlighted, .overview-tile:selected, .grid-search-result:selected {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+  transition-duration: 0ms;
+  border-image: none;
+  background-image: none;
+}
+
+.overview-tile:active, .grid-search-result:active, .overview-tile:checked, .grid-search-result:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+  transition-duration: 150ms;
+  color: white;
+}
+
+.overview-tile .overview-icon.overview-icon-with-label > StBoxLayout, .grid-search-result .overview-icon.overview-icon-with-label > StBoxLayout {
+  spacing: 6px;
+}
+
+.notification-badge {
+  min-width: 16px;
+  min-height: 16px;
+  color: white;
+  background-color: #3281EA;
+  border-radius: 9999px;
+  padding: 0.2em 0.4em;
+  text-align: center;
+}
+
+.app-folder {
+  background-color: rgba(255, 255, 255, 0.04);
+  border-radius: 20px;
+}
+
+.app-folder:focus, .app-folder:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.app-folder:active, .app-folder:highlighted, .app-folder:selected, .app-folder:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder:insensitive {
+  background-color: transparent;
+}
+
+.app-grid-running-dot {
+  width: 6px;
+  height: 3px;
+  border-radius: 2px;
+  background-color: rgba(255, 255, 255, 0.3);
+  margin-bottom: 1px;
+}
+
+StWidget.focused .app-grid-running-dot {
+  width: 18px;
+  background-color: #3281EA;
+}
+
+.app-folder-dialog-container {
+  padding-top: 38px;
+}
+
+.app-folder-dialog {
+  border-radius: 40px;
+  border: none;
+  background-color: rgba(36, 36, 36, 0.95);
+  color: white;
+  spacing: 6px;
+  box-shadow: none;
+  outline: none;
+}
+
+.app-folder-dialog .folder-name-container {
+  padding: 24px 36px 0;
+  spacing: 12px;
+  /* FIXME: this is to keep the label in sync with the entry */
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label,
+.app-folder-dialog .folder-name-container .folder-name-entry {
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry {
+  min-height: 28px;
+  padding: 6px;
+  border: none;
+  color: white;
+  background-color: rgba(255, 255, 255, 0.15);
+  caret-color: white;
+  selection-background-color: rgba(255, 255, 255, 0.12) !important;
+  selected-color: white !important;
+  width: 300px;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:hover .search-entry-icon, .app-folder-dialog .folder-name-container .folder-name-entry:focus .search-entry-icon {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:insensitive, .app-folder-dialog .folder-name-container .folder-name-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label {
+  padding: 5px 7px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.app-folder-dialog .folder-name-container .icon-button, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button, .app-folder-dialog .folder-name-container .background-app-item .close-button, .background-app-item .app-folder-dialog .folder-name-container .close-button {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.7);
+  border: none;
+  height: 32px;
+  width: 32px;
+  padding: 6px;
+  border-radius: 9999px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button > StIcon, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button > StIcon, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button > StIcon,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button > StIcon,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button > StIcon, .app-folder-dialog .folder-name-container .background-app-item .close-button > StIcon, .background-app-item .app-folder-dialog .folder-name-container .close-button > StIcon {
+  icon-size: 16px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button:hover, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:hover, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:hover,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:hover,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:hover, .app-folder-dialog .folder-name-container .background-app-item .close-button:hover, .background-app-item .app-folder-dialog .folder-name-container .close-button:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.app-folder-dialog .folder-name-container .icon-button:checked, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:checked, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:checked,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:checked,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:checked, .app-folder-dialog .folder-name-container .background-app-item .close-button:checked, .background-app-item .app-folder-dialog .folder-name-container .close-button:checked, .app-folder-dialog .folder-name-container .icon-button:active, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:active, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:active,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:active,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:active, .app-folder-dialog .folder-name-container .background-app-item .close-button:active, .background-app-item .app-folder-dialog .folder-name-container .close-button:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder-dialog .icon-grid {
+  row-spacing: 12px;
+  column-spacing: 30px;
+  page-padding-top: 0;
+  page-padding-bottom: 0;
+  page-padding-left: 0;
+  page-padding-right: 0;
+}
+
+.app-folder-dialog .page-indicators {
+  margin-bottom: 18px;
+}
+
+.rename-folder-popup .rename-folder-popup-item {
+  spacing: 6px;
+}
+
+.rename-folder-popup .rename-folder-popup-item:ltr, .rename-folder-popup .rename-folder-popup-item:rtl {
+  padding: 0 12px;
+}
+
+.app-menu,
+.app-well-menu {
+  max-width: 27.25em;
+}
+
+.page-indicator {
+  padding: 6px 12px 0;
+}
+
+.page-indicator .page-indicator-icon {
+  width: 10px;
+  height: 10px;
+  border-radius: 10px;
+  background-color: white;
+  transition-duration: 400ms;
+}
+
+.apps-scroll-view {
+  padding: 0;
+}
+
+.system-action-icon {
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  border-radius: 9999px;
+}
+
+.page-navigation-hint.dnd {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.page-navigation-hint.next:ltr, .page-navigation-hint.previous:rtl {
+  background-gradient-start: rgba(255, 255, 255, 0.05);
+  background-gradient-end: transparent;
+  background-gradient-direction: horizontal;
+  border-radius: 15px 0px 0px 15px;
+}
+
+.page-navigation-hint.previous:ltr, .page-navigation-hint.next:rtl {
+  background-gradient-start: transparent;
+  background-gradient-end: rgba(255, 255, 255, 0.05);
+  background-gradient-direction: horizontal;
+  border-radius: 0px 15px 15px 0px;
+}
+
+.page-navigation-arrow {
+  margin: 6px;
+  padding: 18px;
+  width: 24px;
+  height: 24px;
+  border-radius: 9999px;
+  color: white;
+  background-color: transparent;
+}
+
+.page-navigation-arrow:insensitive {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.page-navigation-arrow:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.page-navigation-arrow:active {
+  background-color: rgba(255, 255, 255, 0.24);
+  color: white;
+}
+
+/* Workspace pager */
+.workspace-thumbnails .workspace-thumbnail {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border: none;
+}
+
+.workspace-thumbnails {
+  visible-width: 32px;
+  spacing: 6px;
+  padding: 6px;
+}
+
+.workspace-thumbnails .workspace-thumbnail {
+  border-radius: 3px;
+}
+
+.workspace-thumbnails .placeholder {
+  background-image: url("resource:///org/gnome/shell/theme/dash-placeholder.svg");
+  background-size: contain;
+  width: 18px;
+}
+
+.workspace-thumbnail-indicator {
+  border: 3px solid #3281EA;
+  border-radius: 3px;
+  padding: 0px;
+}
+
+.ripple-pointer-location {
+  width: 48px;
+  height: 48px;
+  border-radius: 24px;
+  background-color: rgba(189, 214, 248, 0.3);
+  box-shadow: 0 0 2px 2px #8fbaf3;
+}
+
+.pie-timer {
+  width: 60px;
+  height: 60px;
+  -pie-border-width: 3px;
+  -pie-border-color: #3281EA;
+  -pie-background-color: rgba(235, 243, 253, 0.3);
+}
+
+.magnifier-zoom-region {
+  border: 2px solid #3281EA;
+}
+
+.magnifier-zoom-region.full-screen {
+  border-width: 0;
+}
+
+.select-area-rubberband {
+  background-color: rgba(50, 129, 234, 0.3);
+  border: 1px solid #3281EA;
+}
+
+.user-icon {
+  background-size: contain;
+  color: rgba(255, 255, 255, 0.7);
+  border-radius: 9999px;
+  icon-size: 64px;
+}
+
+.user-icon:hover {
+  color: white;
+}
+
+.user-icon StIcon {
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 99px;
+  padding: 12px;
+  width: 40px;
+  height: 40px;
+}
+
+.user-icon.user-avatar {
+  border: 2px rgba(255, 255, 255, 0.7);
+}
+
+.user-widget.vertical .user-icon {
+  icon-size: 128px;
+}
+
+.user-widget.vertical .user-icon StIcon {
+  padding: 20px;
+  padding-top: 18px;
+  padding-bottom: 22px;
+  width: 88px;
+  height: 88px;
+}
+
+.lightbox {
+  background-color: black;
+}
+
+.flashspot {
+  background-color: white;
+}
+
+.hidden {
+  color: rgba(0, 0, 0, 0);
+}
+
+.caps-lock-warning-label {
+  text-align: center;
+  padding-bottom: 8px;
+  font-size: 10.5pt;
+  font-weight: 400;
+  color: #FBC02D;
+}
+
+/* Workspace animation */
+.workspace-animation {
+  background-color: #242424;
+}
+
+/* Tiled window previews */
+.tile-preview {
+  background-color: rgba(50, 129, 234, 0.3);
+  border: 1px solid #3281EA;
+}
+
+.tile-preview-left.on-primary {
+  border-radius: 11px 0 0 0;
+}
+
+.tile-preview-right.on-primary {
+  border-radius: 0 11px 0 0;
+}
+
+.tile-preview-left.tile-preview-right.on-primary {
+  border-radius: 11px 11px 0 0;
+}
+
+/* On-screen Keyboard */
+#keyboard {
+  background-color: rgba(0, 0, 0, 0.85);
+  border: none;
+  border-top-width: 0;
+  box-shadow: none;
+}
+
+#keyboard .page-indicator {
+  padding: 6px;
+}
+
+#keyboard .page-indicator .page-indicator-icon {
+  width: 8px;
+  height: 8px;
+}
+
+.key-container {
+  padding: 4px;
+  spacing: 4px;
+}
+
+.keyboard-key {
+  min-height: 2em;
+  min-width: 2em;
+  font-size: 14pt;
+  font-weight: bold;
+  border-radius: 10px;
+  border: none;
+  color: inherit;
+  background-color: #212121;
+  box-shadow: 0 1px rgba(0, 0, 0, 0.2);
+}
+
+.keyboard-key:focus, .keyboard-key:hover {
+  color: white;
+  background-color: #3b3b3b;
+}
+
+.keyboard-key:checked, .keyboard-key:active {
+  color: white;
+  background-color: #545454;
+}
+
+.keyboard-key:grayed {
+  background-color: #242424;
+  color: white;
+  border-color: #242424;
+}
+
+.keyboard-key.default-key {
+  background-color: #0F0F0F;
+  box-shadow: 0 1px rgba(0, 0, 0, 0.2);
+}
+
+.keyboard-key.default-key:focus, .keyboard-key.default-key:hover {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: #212121;
+}
+
+.keyboard-key.default-key:checked, .keyboard-key.default-key:active {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: #121212;
+}
+
+.keyboard-key.enter-key {
+  background-color: #3281EA;
+  color: white;
+}
+
+.keyboard-key.enter-key:focus, .keyboard-key.enter-key:hover {
+  color: white;
+  background-color: #498fec;
+}
+
+.keyboard-key.enter-key:checked, .keyboard-key.enter-key:active {
+  color: white;
+  background-color: #1667d3;
+}
+
+.keyboard-key.shift-key-uppercase {
+  color: #3281EA;
+}
+
+.keyboard-key StIcon {
+  icon-size: 1.125em;
+}
+
+.keyboard-subkeys {
+  color: inherit;
+  -arrow-border-radius: 10px;
+  -arrow-background-color: rgba(0, 0, 0, 0.45);
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
+  -boxpointer-gap: 5px;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.32);
+}
+
+.emoji-page .keyboard-key {
+  background-color: transparent;
+  border: none;
+  color: initial;
+}
+
+.emoji-panel .keyboard-key:latched {
+  border-color: #498fec;
+  background-color: #3281EA;
+}
+
+.word-suggestions {
+  font-size: 14pt;
+  spacing: 12px;
+  min-height: 20pt;
+}
+
+/* Looking Glass */
+#LookingGlassDialog {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: #242424;
+  spacing: 6px;
+  padding: 0;
+  border: none;
+  border-radius: 20px;
+  box-shadow: 0 10px 15px rgba(0, 0, 0, 0.45);
+}
+
+#LookingGlassDialog > #Toolbar {
+  padding: 6px 9px;
+  border: none;
+  border-radius: 20px 20px 0 0;
+  background-color: #3e3e3e;
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+#LookingGlassDialog .labels {
+  spacing: 0;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+#LookingGlassDialog .notebook-tab {
+  -natural-hpadding: 6px;
+  -minimum-hpadding: 6px;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.5);
+  transition-duration: 150ms;
+  padding-left: 18px;
+  padding-right: 18px;
+  min-height: 24px;
+  border-radius: 10px;
+  background-color: transparent;
+}
+
+#LookingGlassDialog .notebook-tab:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.15);
+  text-shadow: none;
+  box-shadow: none;
+}
+
+#LookingGlassDialog .notebook-tab:selected {
+  background-color: rgba(255, 255, 255, 0.1);
+  box-shadow: none;
+  color: white;
+  text-shadow: none;
+}
+
+#LookingGlassDialog StBoxLayout#EvalBox {
+  padding: 6px;
+  spacing: 6px;
+}
+
+#LookingGlassDialog StBoxLayout#ResultsArea {
+  spacing: 6px;
+}
+
+.lg-dialog StEntry {
+  selection-background-color: #3281EA;
+  selected-color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.lg-dialog .shell-link {
+  color: #3281EA;
+}
+
+.lg-dialog .shell-link:hover {
+  color: #3281EA;
+}
+
+.lg-dialog .actor-link {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.lg-dialog .actor-link:hover {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.lg-dialog .actor-link:active {
+  color: rgba(204, 204, 204, 0.5);
+}
+
+.lg-dialog .actor-link StIcon {
+  icon-size: 12px;
+}
+
+.lg-completions-text {
+  font-size: 1em;
+  font-style: italic;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lg-obj-inspector-title {
+  spacing: 6px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lg-obj-inspector-button {
+  min-height: 36px;
+  padding: 6px;
+  border: none;
+  border-radius: 10px;
+  font-size: 10.5pt;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.lg-obj-inspector-button:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.lg-obj-inspector-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.lg-obj-inspector-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.lg-obj-inspector-button:focus {
+  color: white;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.lg-obj-inspector-button:hover {
+  border: none;
+}
+
+#lookingGlassExtensions {
+  padding: 6px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lg-extensions-list {
+  padding: 6px;
+  spacing: 6px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lg-extension {
+  border: none;
+  border-radius: 10px;
+  background-color: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.7);
+  padding: 6px;
+  box-shadow: none;
+}
+
+.lg-extension-name {
+  font-size: 18pt;
+  font-weight: 400;
+  color: white;
+}
+
+.lg-extension-meta {
+  spacing: 6px;
+}
+
+#LookingGlassPropertyInspector {
+  color: white;
+  background: #333333;
+  border: none;
+  border-radius: 10px;
+  padding: 6px;
+  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.32);
+}
+
+#LookingGlassPropertyInspector .window-close, #LookingGlassPropertyInspector .screenshot-ui-close-button {
+  margin: 6px;
+}
+
+.lg-debug-flag-button {
+  color: white;
+}
+
+.lg-debug-flag-button StLabel {
+  padding: 6px, 12px;
+}
+
+.lg-debug-flag-button:hover {
+  color: white;
+}
+
+.lg-debug-flag-button:active {
+  color: #cccccc;
+}
+
+.lg-debug-flags-header {
+  padding-top: 12px;
+  padding: 6px;
+}
+
+.icon-label-button-container {
+  spacing: 6px;
+  font-size: 9pt;
+  font-weight: 400;
+}
+
+.icon-label-button-container StIcon {
+  icon-size: 32px;
+}
+
+.screenshot-ui-panel {
+  color: white;
+  background-color: #212121;
+  border: none;
+  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.32);
+  border-radius: 31px;
+  padding: 18px;
+  padding-bottom: 12px;
+  margin-bottom: 4em;
+  spacing: 12px;
+}
+
+.screenshot-ui-close-button {
+  padding: 6px !important;
+}
+
+.screenshot-ui-close-button.left {
+  margin-left: 8px;
+}
+
+.screenshot-ui-close-button.right {
+  margin-right: 8px;
+}
+
+.screenshot-ui-type-button {
+  min-width: 48px;
+  padding: 12px 18px !important;
+  border-radius: 13px;
+}
+
+.screenshot-ui-capture-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 9999px;
+  border: 4px white;
+  padding: 4px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle {
+  background-color: white;
+  transition-duration: 200ms;
+  border-radius: 9999px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle:hover, .screenshot-ui-capture-button .screenshot-ui-capture-button-circle:focus {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.screenshot-ui-capture-button:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:focus .screenshot-ui-capture-button-circle {
+  background-color: #d9d9d9;
+}
+
+.screenshot-ui-capture-button:active .screenshot-ui-capture-button-circle {
+  background-color: gray;
+}
+
+.screenshot-ui-capture-button:cast .screenshot-ui-capture-button-circle {
+  background-color: #F44336;
+}
+
+.screenshot-ui-capture-button:cast:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:cast:focus .screenshot-ui-capture-button-circle {
+  background-color: #f55a4e;
+}
+
+.screenshot-ui-capture-button:cast:active .screenshot-ui-capture-button-circle {
+  background-color: #f22314;
+}
+
+.screenshot-ui-shot-cast-container {
+  background-color: rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 3px;
+  spacing: 3px;
+}
+
+.screenshot-ui-shot-cast-container:ltr {
+  margin-left: 3px;
+}
+
+.screenshot-ui-shot-cast-container:rtl {
+  margin-right: 3px;
+}
+
+.screenshot-ui-shot-cast-button {
+  padding: 6px 12px;
+  background-color: transparent;
+  border-radius: 7px;
+}
+
+.screenshot-ui-shot-cast-button:hover, .screenshot-ui-shot-cast-button:focus {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.screenshot-ui-shot-cast-button:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.screenshot-ui-shot-cast-button:checked {
+  background-color: white;
+  color: black;
+}
+
+.screenshot-ui-shot-cast-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-show-pointer-button {
+  border-radius: 9999px;
+  padding: 12px !important;
+}
+
+.screenshot-ui-show-pointer-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-selection {
+  border: 2px white;
+}
+
+.screenshot-ui-area-selector-handle {
+  border-radius: 9999px;
+  background-color: white;
+  box-shadow: 0 1px 3px 2px rgba(0, 0, 0, 0.2);
+  width: 24px;
+  height: 24px;
+}
+
+.screenshot-ui-window-selector {
+  background-color: #242424;
+}
+
+.screenshot-ui-window-selector .screenshot-ui-window-selector-window-container {
+  margin: 100px;
+}
+
+.screenshot-ui-window-selector:primary-monitor .screenshot-ui-window-selector-window-container {
+  margin-bottom: 200px;
+}
+
+.screenshot-ui-window-selector-window-border {
+  transition-duration: 200ms;
+  border-radius: 10px;
+  border: 6px transparent;
+}
+
+.screenshot-ui-window-selector-check {
+  transition-duration: 200ms;
+  color: transparent;
+  border-radius: 9999px;
+  border-width: 12px;
+  icon-size: 24px;
+}
+
+.screenshot-ui-window-selector-window:hover .screenshot-ui-window-selector-window-border {
+  border-color: #135cbc;
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-window-border {
+  border-color: #3281EA;
+  background-color: rgba(50, 129, 234, 0.2);
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-check {
+  color: white;
+  background-color: #3281EA;
+}
+
+.screenshot-ui-screen-selector {
+  transition-duration: 200ms;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-screen-selector:hover {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-screen-selector:active {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.screenshot-ui-screen-selector:checked {
+  background-color: transparent;
+  border: 2px white;
+}
+
+.screenshot-ui-tooltip {
+  color: white;
+  background-color: #242424;
+  border-radius: 9999px;
+  padding: 6px 12px;
+  text-align: center;
+  -y-offset: 24px;
+}
+
+/* Login Dialog */
+.login-dialog-banner-view {
+  padding-top: 24px;
+  max-width: 23em;
+}
+
+.login-dialog,
+.unlock-dialog {
+  border: none;
+  background-color: transparent;
+}
+
+.login-dialog StEntry,
+.unlock-dialog StEntry {
+  selection-background-color: #3281EA;
+  selected-color: white !important;
+  caret-color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.12);
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.login-dialog StEntry:focus,
+.unlock-dialog StEntry:focus {
+  color: white;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #3281EA !important;
+}
+
+.login-dialog StEntry:insensitive,
+.unlock-dialog StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .modal-dialog-button-box,
+.unlock-dialog .modal-dialog-button-box {
+  spacing: 3px;
+}
+
+.login-dialog .modal-dialog-button,
+.unlock-dialog .modal-dialog-button {
+  padding: 4px 18px;
+  box-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:hover, .login-dialog .modal-dialog-button:focus,
+.unlock-dialog .modal-dialog-button:hover,
+.unlock-dialog .modal-dialog-button:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:active,
+.unlock-dialog .modal-dialog-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:insensitive,
+.unlock-dialog .modal-dialog-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default,
+.unlock-dialog .modal-dialog-button:default {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: #3281EA;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:hover, .login-dialog .modal-dialog-button:default:focus,
+.unlock-dialog .modal-dialog-button:default:hover,
+.unlock-dialog .modal-dialog-button:default:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:active,
+.unlock-dialog .modal-dialog-button:default:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.24);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:insensitive,
+.unlock-dialog .modal-dialog-button:default:insensitive {
+  color: rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .cancel-button,
+.login-dialog .switch-user-button,
+.login-dialog .login-dialog-session-list-button,
+.unlock-dialog .cancel-button,
+.unlock-dialog .switch-user-button,
+.unlock-dialog .login-dialog-session-list-button {
+  padding: 0;
+  border-radius: 99px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background-color: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .cancel-button:hover, .login-dialog .cancel-button:focus,
+.login-dialog .switch-user-button:hover,
+.login-dialog .switch-user-button:focus,
+.login-dialog .login-dialog-session-list-button:hover,
+.login-dialog .login-dialog-session-list-button:focus,
+.unlock-dialog .cancel-button:hover,
+.unlock-dialog .cancel-button:focus,
+.unlock-dialog .switch-user-button:hover,
+.unlock-dialog .switch-user-button:focus,
+.unlock-dialog .login-dialog-session-list-button:hover,
+.unlock-dialog .login-dialog-session-list-button:focus {
+  color: white;
+}
+
+.login-dialog .cancel-button:active,
+.login-dialog .switch-user-button:active,
+.login-dialog .login-dialog-session-list-button:active,
+.unlock-dialog .cancel-button:active,
+.unlock-dialog .switch-user-button:active,
+.unlock-dialog .login-dialog-session-list-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.login-dialog .cancel-button StIcon,
+.login-dialog .switch-user-button StIcon,
+.login-dialog .login-dialog-session-list-button StIcon,
+.unlock-dialog .cancel-button StIcon,
+.unlock-dialog .switch-user-button StIcon,
+.unlock-dialog .login-dialog-session-list-button StIcon {
+  icon-size: 16px;
+}
+
+.login-dialog .caps-lock-warning-label,
+.login-dialog .login-dialog-message-warning,
+.unlock-dialog .caps-lock-warning-label,
+.unlock-dialog .login-dialog-message-warning {
+  color: white;
+}
+
+.login-dialog-logo-bin {
+  padding: 24px 0px;
+}
+
+.login-dialog-banner {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-button-box {
+  width: 23em;
+  spacing: 5px;
+}
+
+.login-dialog-message {
+  text-align: center;
+}
+
+.login-dialog-user-selection-box {
+  padding: 100px 0px;
+}
+
+.login-dialog-not-listed-label {
+  padding-left: 2px;
+  font-size: 1em;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.7);
+  padding-top: 1em;
+}
+
+.login-dialog-not-listed-label:hover {
+  color: white;
+}
+
+.login-dialog-not-listed-label:focus {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.login-dialog-not-listed-button:focus .login-dialog-not-listed-label, .login-dialog-not-listed-button:hover .login-dialog-not-listed-label {
+  color: white;
+}
+
+.login-dialog-user-list-view {
+  -st-vfade-offset: 1em;
+}
+
+.login-dialog-user-list {
+  spacing: 12px;
+  width: 23em;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:selected {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: white;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:logged-in {
+  border-right: 2px solid white;
+}
+
+.login-dialog-user-list-item {
+  border-radius: 10px;
+  padding: 6px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-user-list-item:ltr {
+  padding-right: 1em;
+}
+
+.login-dialog-user-list-item:rtl {
+  padding-left: 1em;
+}
+
+.login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: white;
+}
+
+.login-dialog-user-list-item .login-dialog-timed-login-indicator {
+  height: 2px;
+  margin: 6px 0 0 0;
+  background-color: white;
+}
+
+.login-dialog-user-list-item:focus .login-dialog-timed-login-indicator {
+  background-color: white;
+}
+
+.user-widget-label {
+  color: white;
+}
+
+.user-widget.horizontal .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+  padding-left: 15px;
+}
+
+.user-widget.horizontal .user-widget-label:ltr {
+  padding-left: 14px;
+  text-align: left;
+}
+
+.user-widget.horizontal .user-widget-label:rtl {
+  padding-right: 14px;
+  text-align: right;
+}
+
+.user-widget.vertical .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  text-align: center;
+  font-weight: normal;
+  padding-top: 16px;
+}
+
+.login-dialog-prompt-layout {
+  padding-top: 24px;
+  padding-bottom: 12px;
+  spacing: 12px;
+  width: 23em;
+}
+
+.login-dialog-prompt-entry {
+  height: 1.5em;
+}
+
+.login-dialog-prompt-label {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 1em;
+  padding-top: 1em;
+}
+
+/* Screen Shield */
+.unlock-dialog-clock {
+  color: white;
+  font-weight: 300;
+  text-align: center;
+  spacing: 24px;
+  padding-bottom: 2.5em;
+}
+
+.unlock-dialog-clock-time {
+  font-size: 64pt;
+  padding-top: 42px;
+  font-feature-settings: "tnum";
+}
+
+.unlock-dialog-clock-date {
+  font-size: 16pt;
+  font-weight: normal;
+}
+
+.unlock-dialog-clock-hint {
+  font-weight: normal;
+  padding-top: 48px;
+}
+
+.unlock-dialog-notifications-container {
+  margin: 12px 0;
+  spacing: 6px;
+  width: 23em;
+  background-color: transparent;
+}
+
+.unlock-dialog-notifications-container .summary-notification-stack-scrollview {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.unlock-dialog-notifications-container .notification,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source {
+  padding: 12px 6px;
+  border: none;
+  background-color: rgba(25, 25, 25, 0.9);
+  color: white;
+  border-radius: 10px;
+}
+
+.unlock-dialog-notifications-container .notification.critical,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source.critical {
+  background-color: rgba(36, 36, 36, 0.9);
+}
+
+.unlock-dialog-notification-label {
+  padding: 0px 0px 0px 12px;
+}
+
+.unlock-dialog-notification-count-text {
+  weight: bold;
+  padding: 0 6px;
+  color: rgba(25, 25, 25, 0.9);
+  background-color: rgba(255, 255, 255, 0.7);
+  border-radius: 99px;
+  margin-right: 12px;
+}
+
+.screen-shield-background {
+  background: black;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.6);
+}
+
+#lockDialogGroup {
+  background-color: #242424;
+}
+
+#unlockDialogNotifications StButton#vhandle, #unlockDialogNotifications StButton#hhandle {
+  background-color: rgba(25, 25, 25, 0.2);
+}
+
+#unlockDialogNotifications StButton#vhandle:hover, #unlockDialogNotifications StButton#vhandle:focus, #unlockDialogNotifications StButton#hhandle:hover, #unlockDialogNotifications StButton#hhandle:focus {
+  background-color: rgba(25, 25, 25, 0.4);
+}
+
+#unlockDialogNotifications StButton#vhandle:active, #unlockDialogNotifications StButton#hhandle:active {
+  background-color: rgba(50, 129, 234, 0.5);
+}
+
+.bottom #dashtodockDashScrollview,
+.top #dashtodockDashScrollview {
+  -st-hfade-offset: 24px;
+}
+
+.left #dashtodockDashScrollview,
+.right #dashtodockDashScrollview {
+  -st-vfade-offset: 24px;
+}
+
+#dashtodockContainer {
+  background: transparent;
+}
+
+#dashtodockContainer .number-overlay {
+  min-width: 1.2em;
+  min-height: 1.2em;
+  color: white;
+  background-color: rgba(0, 0, 0, 0.75);
+  text-align: center;
+  padding: 0.2em 0.4em;
+}
+
+#dashtodockContainer .notification-badge {
+  min-width: 16px;
+  min-height: 16px;
+  color: white;
+  background-color: #3281EA;
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.25);
+  border-radius: 9999px;
+  margin: 2px 3px 5px;
+  padding: 0.2em 0.4em;
+  font-weight: bold;
+  text-align: center;
+}
+
+#dashtodockContainer.top #dash .dash-background {
+  border-radius: 9999px !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash, #dashtodockContainer.top.shrink.straight-corner #dash, #dashtodockContainer.top.extended #dash, #dashtodockContainer.top.shrink.extended #dash {
+  margin: 0 !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .dash-background, #dashtodockContainer.top.shrink.straight-corner #dash .dash-background, #dashtodockContainer.top.extended #dash .dash-background, #dashtodockContainer.top.shrink.extended #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .show-apps,
+#dashtodockContainer.top.straight-corner #dash .overview-tile,
+#dashtodockContainer.top.straight-corner #dash .grid-search-result, #dashtodockContainer.top.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.top.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.top.extended #dash .show-apps,
+#dashtodockContainer.top.extended #dash .overview-tile,
+#dashtodockContainer.top.extended #dash .grid-search-result, #dashtodockContainer.top.shrink.extended #dash .show-apps,
+#dashtodockContainer.top.shrink.extended #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.bottom #dash .dash-background {
+  border-radius: 9999px !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash, #dashtodockContainer.bottom.shrink.straight-corner #dash, #dashtodockContainer.bottom.extended #dash, #dashtodockContainer.bottom.shrink.extended #dash {
+  margin: 0 !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .dash-background, #dashtodockContainer.bottom.shrink.straight-corner #dash .dash-background, #dashtodockContainer.bottom.extended #dash .dash-background, #dashtodockContainer.bottom.shrink.extended #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.straight-corner #dash .overview-tile,
+#dashtodockContainer.bottom.straight-corner #dash .grid-search-result, #dashtodockContainer.bottom.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.bottom.extended #dash .show-apps,
+#dashtodockContainer.bottom.extended #dash .overview-tile,
+#dashtodockContainer.bottom.extended #dash .grid-search-result, #dashtodockContainer.bottom.shrink.extended #dash .show-apps,
+#dashtodockContainer.bottom.shrink.extended #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.left #dash .dash-background {
+  border-radius: 9999px !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash, #dashtodockContainer.left.shrink.straight-corner #dash, #dashtodockContainer.left.extended #dash, #dashtodockContainer.left.shrink.extended #dash {
+  margin: 0 !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .dash-background, #dashtodockContainer.left.shrink.straight-corner #dash .dash-background, #dashtodockContainer.left.extended #dash .dash-background, #dashtodockContainer.left.shrink.extended #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .show-apps,
+#dashtodockContainer.left.straight-corner #dash .overview-tile,
+#dashtodockContainer.left.straight-corner #dash .grid-search-result, #dashtodockContainer.left.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.left.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.left.extended #dash .show-apps,
+#dashtodockContainer.left.extended #dash .overview-tile,
+#dashtodockContainer.left.extended #dash .grid-search-result, #dashtodockContainer.left.shrink.extended #dash .show-apps,
+#dashtodockContainer.left.shrink.extended #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.right #dash .dash-background {
+  border-radius: 9999px !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash, #dashtodockContainer.right.shrink.straight-corner #dash, #dashtodockContainer.right.extended #dash, #dashtodockContainer.right.shrink.extended #dash {
+  margin: 0 !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .dash-background, #dashtodockContainer.right.shrink.straight-corner #dash .dash-background, #dashtodockContainer.right.extended #dash .dash-background, #dashtodockContainer.right.shrink.extended #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .show-apps,
+#dashtodockContainer.right.straight-corner #dash .overview-tile,
+#dashtodockContainer.right.straight-corner #dash .grid-search-result, #dashtodockContainer.right.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.right.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.right.extended #dash .show-apps,
+#dashtodockContainer.right.extended #dash .overview-tile,
+#dashtodockContainer.right.extended #dash .grid-search-result, #dashtodockContainer.right.shrink.extended #dash .show-apps,
+#dashtodockContainer.right.shrink.extended #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.extended .dash-background, #dashtodockContainer.straight-corner .dash-background {
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.shrink .dash-background {
+  padding: 2px !important;
+}
+
+#dashtodockContainer.shrink .show-apps,
+#dashtodockContainer.shrink .overview-tile,
+#dashtodockContainer.shrink .grid-search-result {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.shrink.extended .dash-background {
+  border-radius: 0;
+}
+
+#dashtodockContainer #dash, #dashtodockContainer:overview #dash {
+  background: transparent;
+}
+
+#dashtodockContainer.left #dash, #dashtodockContainer.right #dash {
+  margin-top: 0 !important;
+  padding: 12px !important;
+}
+
+#dashtodockContainer.left #dash #dashtodockDashContainer, #dashtodockContainer.right #dash #dashtodockDashContainer {
+  padding: 10px 0 !important;
+}
+
+#dashtodockContainer.left .show-apps,
+#dashtodockContainer.left .overview-tile,
+#dashtodockContainer.left .grid-search-result, #dashtodockContainer.right .show-apps,
+#dashtodockContainer.right .overview-tile,
+#dashtodockContainer.right .grid-search-result {
+  padding: 2px 6px !important;
+}
+
+#dashtodockContainer.left .dash-background, #dashtodockContainer.right .dash-background {
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.left.shrink #dash #dashtodockDashContainer, #dashtodockContainer.right.shrink #dash #dashtodockDashContainer {
+  padding: 4px 0 !important;
+}
+
+#dashtodockContainer.left.shrink .dash-background, #dashtodockContainer.right.shrink .dash-background {
+  padding: 4px !important;
+}
+
+#dashtodockContainer.left.shrink .show-apps,
+#dashtodockContainer.left.shrink .overview-tile,
+#dashtodockContainer.left.shrink .grid-search-result, #dashtodockContainer.right.shrink .show-apps,
+#dashtodockContainer.right.shrink .overview-tile,
+#dashtodockContainer.right.shrink .grid-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer, #dashtodockContainer.right.extended #dash #dashtodockDashContainer, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.right.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child {
+  padding-top: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.right.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child {
+  padding-bottom: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.right.extended #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer > :first-child .show-apps {
+  padding-bottom: 6px !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.right.extended #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer > :last-child .show-apps {
+  padding-bottom: 24px !important;
+}
+
+#dashtodockContainer.left.extended.shrink .dash-background, #dashtodockContainer.left.straight-corner.shrink .dash-background, #dashtodockContainer.right.extended.shrink .dash-background, #dashtodockContainer.right.straight-corner.shrink .dash-background {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended.shrink .show-apps,
+#dashtodockContainer.left.extended.shrink .overview-tile,
+#dashtodockContainer.left.extended.shrink .grid-search-result, #dashtodockContainer.left.straight-corner.shrink .show-apps,
+#dashtodockContainer.left.straight-corner.shrink .overview-tile,
+#dashtodockContainer.left.straight-corner.shrink .grid-search-result, #dashtodockContainer.right.extended.shrink .show-apps,
+#dashtodockContainer.right.extended.shrink .overview-tile,
+#dashtodockContainer.right.extended.shrink .grid-search-result, #dashtodockContainer.right.straight-corner.shrink .show-apps,
+#dashtodockContainer.right.straight-corner.shrink .overview-tile,
+#dashtodockContainer.right.straight-corner.shrink .grid-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended .overview-tile, #dashtodockContainer.left.extended .grid-search-result, #dashtodockContainer.left.straight-corner .overview-tile, #dashtodockContainer.left.straight-corner .grid-search-result, #dashtodockContainer.right.extended .overview-tile, #dashtodockContainer.right.extended .grid-search-result, #dashtodockContainer.right.straight-corner .overview-tile, #dashtodockContainer.right.straight-corner .grid-search-result {
+  padding: 2px 12px !important;
+}
+
+#dashtodockContainer.left.extended .show-apps, #dashtodockContainer.left.straight-corner .show-apps, #dashtodockContainer.right.extended .show-apps, #dashtodockContainer.right.straight-corner .show-apps {
+  padding: 2px 12px 24px !important;
+}
+
+#dashtodockContainer.top .dash-background, #dashtodockContainer.bottom .dash-background {
+  padding: 12px 10px !important;
+}
+
+#dashtodockContainer.top .show-apps,
+#dashtodockContainer.top .overview-tile,
+#dashtodockContainer.top .grid-search-result, #dashtodockContainer.bottom .show-apps,
+#dashtodockContainer.bottom .overview-tile,
+#dashtodockContainer.bottom .grid-search-result {
+  margin: 0 2px !important;
+  padding-bottom: 12px !important;
+}
+
+#dashtodockContainer.top .show-apps .overview-icon,
+#dashtodockContainer.top .overview-tile .overview-icon,
+#dashtodockContainer.top .grid-search-result .overview-icon, #dashtodockContainer.bottom .show-apps .overview-icon,
+#dashtodockContainer.bottom .overview-tile .overview-icon,
+#dashtodockContainer.bottom .grid-search-result .overview-icon {
+  padding: 6px !important;
+  spacing: 6px !important;
+}
+
+#dashtodockContainer.top.shrink .dash-background, #dashtodockContainer.bottom.shrink .dash-background {
+  padding: 4px 2px !important;
+}
+
+#dashtodockContainer.top.shrink .show-apps,
+#dashtodockContainer.top.shrink .overview-tile,
+#dashtodockContainer.top.shrink .grid-search-result, #dashtodockContainer.bottom.shrink .show-apps,
+#dashtodockContainer.bottom.shrink .overview-tile,
+#dashtodockContainer.bottom.shrink .grid-search-result {
+  margin: 0 !important;
+  padding: 0 2px 12px !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child {
+  padding-left: 0 !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child {
+  padding-right: 0 !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer > :first-child .show-apps {
+  padding-left: 0 !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer > :last-child .show-apps {
+  padding-right: 18px !important;
+}
+
+#dashtodockContainer.top.extended.shrink .dash-background, #dashtodockContainer.top.straight-corner.shrink .dash-background, #dashtodockContainer.bottom.extended.shrink .dash-background, #dashtodockContainer.bottom.straight-corner.shrink .dash-background {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.extended.shrink .show-apps,
+#dashtodockContainer.top.extended.shrink .overview-tile,
+#dashtodockContainer.top.extended.shrink .grid-search-result, #dashtodockContainer.top.straight-corner.shrink .show-apps,
+#dashtodockContainer.top.straight-corner.shrink .overview-tile,
+#dashtodockContainer.top.straight-corner.shrink .grid-search-result, #dashtodockContainer.bottom.extended.shrink .show-apps,
+#dashtodockContainer.bottom.extended.shrink .overview-tile,
+#dashtodockContainer.bottom.extended.shrink .grid-search-result, #dashtodockContainer.bottom.straight-corner.shrink .show-apps,
+#dashtodockContainer.bottom.straight-corner.shrink .overview-tile,
+#dashtodockContainer.bottom.straight-corner.shrink .grid-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.extended .dash-separator, #dashtodockContainer.top.straight-corner .dash-separator, #dashtodockContainer.bottom.extended .dash-separator, #dashtodockContainer.bottom.straight-corner .dash-separator {
+  margin: 0 8px !important;
+}
+
+#dashtodockContainer.top.extended .show-apps,
+#dashtodockContainer.top.extended .overview-tile,
+#dashtodockContainer.top.extended .grid-search-result, #dashtodockContainer.top.straight-corner .show-apps,
+#dashtodockContainer.top.straight-corner .overview-tile,
+#dashtodockContainer.top.straight-corner .grid-search-result, #dashtodockContainer.bottom.extended .show-apps,
+#dashtodockContainer.bottom.extended .overview-tile,
+#dashtodockContainer.bottom.extended .grid-search-result, #dashtodockContainer.bottom.straight-corner .show-apps,
+#dashtodockContainer.bottom.straight-corner .overview-tile,
+#dashtodockContainer.bottom.straight-corner .grid-search-result {
+  padding: 12px 2px !important;
+}
+
+#dashtodockContainer #dash .dash-background {
+  background-color: rgba(33, 33, 33, 0.65);
+}
+
+#dashtodockContainer #dash .app-grid-running-dot {
+  margin-bottom: 3px !important;
+  margin-top: 0 !important;
+  offset-y: 0 !important;
+}
+
+#dashtodockContainer #dash StWidget.focused .app-grid-running-dot {
+  background-color: #3281EA;
+}
+
+#dashtodockContainer.opaque #dash .dash-background {
+  background-color: #212121;
+}
+
+#dashtodockContainer.transparent #dash .dash-background {
+  background-color: rgba(33, 33, 33, 0.65);
+}
+
+#dashtodockContainer:overview #dash {
+  background: none;
+}
+
+#dashtodockContainer:overview #dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#dashtodockContainer:overview #dash StWidget.focused .app-grid-running-dot {
+  background-color: #3281EA;
+}
+
+#dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
+  background-color: transparent !important;
+  box-shadow: none !important;
+}
+
+#dashtodockContainer.opaque:overview .dash-background, #dashtodockContainer.transparent:overview .dash-background {
+  background-color: transparent !important;
+}
+
+#dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
+  background: none;
+}
+
+#dashtodockContainer.running-dots .dash-item-container > StButton, #dashtodockContainer.dashtodock .dash-item-container > StButton {
+  transition-duration: 250ms;
+  background-size: contain;
+}
+
+#dashtodockContainer.shrink .dash-item-container > StButton, #dashtodockContainer.dashtodock .dash-item-container > StButton {
+  padding: 1px 2px;
+}
+
+#dashtodockContainer.extended .overview-tile .overview-icon, #dashtodockContainer.extended .grid-search-result .overview-icon,
+#dashtodockContainer.extended .show-apps .overview-icon, #dashtodockContainer.extended:overview .overview-tile .overview-icon,
+#dashtodockContainer.extended:overview .show-apps .overview-icon {
+  border-radius: 10px;
+}
+
+#dashtodockContainer .metro .overview-icon {
+  border-radius: 0;
+}
+
+.dashtodock-app-well-preview-menu-item {
+  padding: 1em 1em 0.5em 1em;
+}
+
+#dashtodockPreviewSeparator.popup-separator-menu-item-horizontal {
+  width: 1px;
+  height: auto;
+  border-right-width: 1px;
+  margin: 32px 0;
+}
+
+.dash-label.bottom {
+  margin-bottom: 18px !important;
+}
+
+.dashtopanelMainPanel {
+  border-radius: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+.dashtopanelMainPanel .dash-background {
+  background-color: rgba(33, 33, 33, 0.65);
+  margin-bottom: 0 !important;
+  padding: 0 !important;
+  border-radius: 0 !important;
+}
+
+.dashtopanelMainPanel .overview-tile, .dashtopanelMainPanel .grid-search-result {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .overview-tile .overview-icon, .dashtopanelMainPanel .grid-search-result .overview-icon {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .show-apps {
+  color: white !important;
+  border-radius: 0 !important;
+}
+
+.dashtopanelMainPanel .show-apps:hover {
+  background: rgba(255, 255, 255, 0.12) !important;
+}
+
+.dashtopanelMainPanel .show-apps:active {
+  background: rgba(255, 255, 255, 0.3) !important;
+}
+
+.dashtopanelMainPanel .panel-button, .dashtopanelMainPanel .panel-button.clock-display .clock {
+  border-radius: 8px !important;
+  margin: 0 !important;
+}
+
+.dashtopanelMainPanel .arcmenu-menu-button {
+  border-radius: 5px !important;
+  padding: 8px 6px !important;
+}
+
+.popup-menu.panel-menu .popup-menu-content, .popup-menu.panel-menu.quick-settings .popup-menu-content {
+  margin-bottom: 3px !important;
+}
+
+.dashtopanelSecondaryMenu {
+  border-radius: 12px !important;
+}
+
+#preview-menu {
+  margin: 6px !important;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2) !important;
+  border-radius: 12px !important;
+  padding: 0 !important;
+}
+
+#dashtopanelPreviewScrollview {
+  padding: 12px 0 !important;
+  border-radius: 12px !important;
+  background: #0c0c0c !important;
+}
+
+.openweather-button, .openweather-button-action, .openweather-menu-button-container, .openweather-button-box {
+  border: 1px solid transparent;
+}
+
+.openweather-provider {
+  padding: 0 16px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.openweather-provider:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.openweather-provider:focus {
+  color: white;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.openweather-provider:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.openweather-current-icon, .openweather-current-summary, .openweather-current-summarybox {
+  background: none;
+  color: white;
+}
+
+.openweather-current-databox-values {
+  background: none;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.openweather-current-databox-captions {
+  background: none;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.openweather-forecast-icon, .openweather-forecast-summary {
+  background: none;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.openweather-forecast-day, .openweather-forecast-temperature {
+  background: none;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.openweather-sunrise-icon, .openweather-sunset-icon, .openweather-build-icon {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.popup-sub-menu .openweather-current-icon, .popup-sub-menu .openweather-current-summary, .popup-sub-menu .openweather-current-summarybox {
+  background: none;
+  color: rgba(0, 0, 0, 0.95);
+}
+
+.popup-sub-menu .openweather-current-databox-values {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.popup-sub-menu .openweather-current-databox-captions {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.popup-sub-menu .openweather-forecast-icon, .popup-sub-menu .openweather-forecast-summary {
+  color: rgba(0, 0, 0, 0.85);
+}
+
+.popup-sub-menu .openweather-forecast-day, .popup-sub-menu .openweather-forecast-temperature {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.popup-sub-menu .openweather-sunrise-icon, .popup-sub-menu .openweather-sunset-icon, .popup-sub-menu .openweather-build-icon {
+  color: rgba(0, 0, 0, 0.85);
+}
+
+.arcmenu-menu-button,
+.arcmenu-button {
+  border-width: 0 !important;
+  border-radius: 9999px !important;
+}
+
+.cosmic-solid-bg {
+  background-color: #242424;
+}
+
+.cosmic-dock #dock {
+  background-color: transparent;
+}
+
+.cosmic-dock #dock .dash-background {
+  background-color: rgba(33, 33, 33, 0.65);
+}
+
+.cosmic-dock.extended #dash {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding: 0 0;
+}
+
+.cosmic-dock.extended #dash .dash-background {
+  border-radius: 0;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.overview-components-transparent .search-entry,
+.overview-components-light .search-entry,
+.overview-components-dark .search-entry {
+  caret-color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.overview-components-transparent .search-entry .search-entry-icon,
+.overview-components-light .search-entry .search-entry-icon,
+.overview-components-dark .search-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.overview-components-transparent .search-entry StLabel.hint-text,
+.overview-components-light .search-entry StLabel.hint-text,
+.overview-components-dark .search-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.35) !important;
+}

--- a/src/gnome-shell/shell-48-0/gnome-shell-Dark.scss
+++ b/src/gnome-shell/shell-48-0/gnome-shell-Dark.scss
@@ -1,0 +1,10 @@
+$variant: 'dark';
+$topbar: 'dark';
+$compact: 'false';
+
+@import '../../_sass/variables';
+@import '../../_sass/colors';
+@import '../../_sass/gnome-shell/drawing';
+@import '../../_sass/gnome-shell/common';
+@import '../../_sass/gnome-shell/widgets-48-0';
+@import '../../_sass/gnome-shell/extensions-46-0';

--- a/src/gnome-shell/shell-48-0/gnome-shell.css
+++ b/src/gnome-shell/shell-48-0/gnome-shell.css
@@ -1,0 +1,5085 @@
+/* This stylesheet is generated, DO NOT EDIT */
+stage {
+  font-size: 10.5pt;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.search-statustext {
+  font-size: 45px;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.modal-dialog .modal-dialog-linked-button, .hotplug-notification-item {
+  border: none;
+  margin-bottom: 6px;
+  color: rgba(0, 0, 0, 0.6);
+  background-color: rgba(0, 0, 0, 0.04);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+  font-size: 10.5pt;
+  font-weight: 500;
+}
+
+.modal-dialog .modal-dialog-linked-button:hover, .hotplug-notification-item:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.modal-dialog .modal-dialog-linked-button:active, .hotplug-notification-item:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.24);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.modal-dialog .modal-dialog-linked-button:insensitive, .hotplug-notification-item:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: rgba(0, 0, 0, 0.04);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.modal-dialog .modal-dialog-linked-button:focus, .hotplug-notification-item:focus {
+  color: #1A73E8;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.modal-dialog .modal-dialog-linked-button:focus:active, .hotplug-notification-item:focus:active {
+  color: white;
+}
+
+.modal-dialog .modal-dialog-linked-button:first-child, .hotplug-notification-item:first-child {
+  margin-left: 6px !important;
+  margin-right: 0 !important;
+  border-radius: 9999px 0 0 9999px;
+}
+
+.modal-dialog .modal-dialog-linked-button:last-child, .hotplug-notification-item:last-child {
+  margin-left: 0 !important;
+  margin-right: 6px !important;
+  border-right-width: 0;
+  border-radius: 0 9999px 9999px 0;
+}
+
+.modal-dialog .modal-dialog-linked-button:first-child:last-child, .hotplug-notification-item:first-child:last-child {
+  margin: 0 6px 6px 6px !important;
+  border-right-width: 0;
+  border-radius: 9999px;
+}
+
+.screenshot-ui-show-pointer-button, .screenshot-ui-type-button {
+  border: none;
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:insensitive, .screenshot-ui-type-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: #242424;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:focus, .screenshot-ui-type-button:focus {
+  color: #1A73E8;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.screenshot-ui-show-pointer-button:focus:active, .screenshot-ui-type-button:focus:active {
+  color: white;
+}
+
+.screenshot-ui-show-pointer-button:hover, .screenshot-ui-type-button:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:active, .screenshot-ui-type-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.24);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:outlined, .screenshot-ui-type-button:outlined, .screenshot-ui-show-pointer-button:checked, .screenshot-ui-type-button:checked {
+  color: white;
+  background-color: #1A73E8;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.workspace-switcher-container, .switcher-list, .resize-popup, .osd-monitor-label, .osd-window {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  border: none;
+  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.32);
+  padding: 12px;
+}
+
+/* General Typography */
+.message-list .message-list-placeholder {
+  font-weight: 800;
+  font-size: 15pt;
+}
+
+.quick-toggle-menu .header .title {
+  font-weight: 700;
+  font-size: 15pt;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  font-weight: 700;
+  font-size: 13pt;
+}
+
+.background-app-item .title, .message-list-controls {
+  font-weight: 700;
+  font-size: 11pt;
+}
+
+.quick-toggle-menu .header .subtitle, .app-menu .popup-inactive-menu-item:first-child > StLabel {
+  font-weight: 700;
+  font-size: 9pt;
+}
+
+.background-app-item .subtitle, .message .message-header .message-header-content .event-time {
+  font-weight: 400;
+  font-size: 9pt;
+}
+
+/* WIDGETS */
+.shell-link {
+  border-radius: 10px;
+  color: #1A73E8;
+  background-color: transparent;
+}
+
+.shell-link:hover {
+  color: #1A73E8;
+  background-color: rgba(26, 115, 232, 0.15);
+}
+
+.shell-link:active {
+  color: #1A73E8;
+  background-color: rgba(26, 115, 232, 0.3);
+}
+
+.lowres-icon {
+  icon-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.icon-dropshadow {
+  icon-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+}
+
+/* Entries */
+StEntry {
+  min-height: 36px;
+  padding: 0 8px;
+  border-radius: 9999px;
+  border-width: 0;
+  selection-background-color: rgba(26, 115, 232, 0.35) !important;
+  selected-color: #1A73E8 !important;
+  font-size: 12pt;
+  font-weight: 400;
+  caret-color: rgba(0, 0, 0, 0.6);
+  color: rgba(0, 0, 0, 0.6);
+  background-color: #FFFFFF;
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+StEntry:hover {
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.12) !important;
+}
+
+StEntry:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #1A73E8 !important;
+}
+
+StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+StEntry StIcon.capslock-warning {
+  icon-size: 16px;
+  warning-color: #FFD600;
+  padding: 0 4px;
+}
+
+StEntry StIcon.peek-password {
+  icon-size: 16px;
+  padding: 0 4px;
+}
+
+StEntry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+/* Buttons */
+.icon-button.flat, .background-app-item .flat.close-button, .message .message-header .flat.message-expand-button,
+.message .message-header .flat.message-close-button, .button.flat {
+  color: rgba(0, 0, 0, 0.6);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button.flat:focus, .background-app-item .flat.close-button:focus, .message .message-header .flat.message-expand-button:focus,
+.message .message-header .flat.message-close-button:focus, .button.flat:focus {
+  color: rgba(0, 0, 0, 0.87);
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.icon-button.flat:hover, .background-app-item .flat.close-button:hover, .message .message-header .flat.message-expand-button:hover,
+.message .message-header .flat.message-close-button:hover, .button.flat:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button.flat:selected, .background-app-item .flat.close-button:selected, .message .message-header .flat.message-expand-button:selected,
+.message .message-header .flat.message-close-button:selected, .button.flat:selected, .icon-button.flat:active, .background-app-item .flat.close-button:active, .message .message-header .flat.message-expand-button:active,
+.message .message-header .flat.message-close-button:active, .button.flat:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button.flat:checked, .background-app-item .flat.close-button:checked, .message .message-header .flat.message-expand-button:checked,
+.message .message-header .flat.message-close-button:checked, .button.flat:checked {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button.flat:insensitive, .background-app-item .flat.close-button:insensitive, .message .message-header .flat.message-expand-button:insensitive,
+.message .message-header .flat.message-close-button:insensitive, .button.flat:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.keyboard-brightness-level .button:checked, .icon-button.default, .background-app-item .default.close-button, .message .message-header .default.message-expand-button,
+.message .message-header .default.message-close-button, .button.default {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: #1A73E8;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.keyboard-brightness-level .button:focus:checked, .icon-button.default:focus, .background-app-item .default.close-button:focus, .message .message-header .default.message-expand-button:focus,
+.message .message-header .default.message-close-button:focus, .button.default:focus {
+  color: #1A73E8;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.keyboard-brightness-level .button:focus:active:checked, .icon-button.default:focus:active, .background-app-item .default.close-button:focus:active, .message .message-header .default.message-expand-button:focus:active,
+.message .message-header .default.message-close-button:focus:active, .button.default:focus:active {
+  color: white;
+}
+
+.keyboard-brightness-level .button:hover:checked, .icon-button.default:hover, .background-app-item .default.close-button:hover, .message .message-header .default.message-expand-button:hover,
+.message .message-header .default.message-close-button:hover, .button.default:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.keyboard-brightness-level .button:insensitive:checked, .icon-button.default:insensitive, .background-app-item .default.close-button:insensitive, .message .message-header .default.message-expand-button:insensitive,
+.message .message-header .default.message-close-button:insensitive, .button.default:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: #1A73E8;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.keyboard-brightness-level .button:active:checked, .icon-button.default:active, .background-app-item .default.close-button:active, .message .message-header .default.message-expand-button:active,
+.message .message-header .default.message-close-button:active, .button.default:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.24);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button {
+  min-height: 24px;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 10px;
+  text-align: center;
+  font-size: 10.5pt;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.6);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:checked {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.icon-button, .background-app-item .close-button, .message .message-header .message-expand-button,
+.message .message-header .message-close-button {
+  min-height: 16px;
+  min-width: 16px;
+  padding: 12px;
+  border-radius: 9999px;
+  border: none;
+  color: rgba(0, 0, 0, 0.6);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:hover, .background-app-item .close-button:hover, .message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:active, .background-app-item .close-button:active, .message .message-header .message-expand-button:active,
+.message .message-header .message-close-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:checked, .background-app-item .close-button:checked, .message .message-header .message-expand-button:checked,
+.message .message-header .message-close-button:checked {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:insensitive, .background-app-item .close-button:insensitive, .message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.icon-button:focus, .background-app-item .close-button:focus, .message .message-header .message-expand-button:focus,
+.message .message-header .message-close-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.icon-button StIcon, .background-app-item .close-button StIcon, .message .message-header .message-expand-button StIcon,
+.message .message-header .message-close-button StIcon {
+  icon-size: 16px;
+  -st-icon-style: symbolic;
+}
+
+/* Check Boxes */
+.check-box StBoxLayout {
+  spacing: .8em;
+}
+
+.check-box StBin {
+  width: 24px;
+  height: 24px;
+  padding: 6px;
+  border-radius: 100px;
+  background-image: url("assets/checkbox-off.svg");
+}
+
+.check-box:focus StBin {
+  background-image: url("assets/checkbox-off.svg");
+}
+
+.check-box:hover StBin {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.check-box:active StBin {
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.check-box:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:focus:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:hover:checked StBin {
+  background-color: rgba(26, 115, 232, 0.15);
+}
+
+.check-box:active:checked StBin {
+  background-color: rgba(26, 115, 232, 0.3);
+}
+
+/* Switches */
+.toggle-switch {
+  width: 44px;
+  height: 26px;
+  background-size: contain;
+  background-image: url("assets/toggle-off.svg");
+}
+
+.toggle-switch:checked {
+  background-image: url("assets/toggle-on.svg");
+}
+
+/* Slider */
+.slider {
+  height: 22px;
+  -barlevel-height: 2px;
+  -barlevel-background-color: rgba(0, 0, 0, 0.26);
+  -barlevel-border-width: 0;
+  -barlevel-border-color: rgba(0, 0, 0, 0.12);
+  -barlevel-active-background-color: #1A73E8;
+  -barlevel-active-border-color: #166ad8;
+  -barlevel-overdrive-color: #E53935;
+  -barlevel-overdrive-border-color: #e32723;
+  -barlevel-overdrive-separator-width: 2px;
+  -slider-handle-radius: 7px;
+  -slider-handle-border-width: 0;
+  -slider-handle-border-color: rgba(0, 0, 0, 0.12);
+  color: #1A73E8;
+}
+
+.slider:hover {
+  color: #3181ea;
+}
+
+.slider:active {
+  color: #1567d3;
+}
+
+/* Scrollbars */
+StScrollView.vfade {
+  -st-vfade-offset: 32px;
+}
+
+StScrollView.hfade {
+  -st-hfade-offset: 32px;
+}
+
+StScrollBar {
+  padding: 0;
+  margin: 6px;
+}
+
+StScrollView StScrollBar {
+  min-width: 8px;
+  min-height: 8px;
+}
+
+StScrollBar StBin#trough {
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+StScrollBar StButton#vhandle, StScrollBar StButton#hhandle {
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.38);
+  border: 4px solid transparent;
+  transition: 500ms all ease;
+}
+
+StScrollBar StButton#vhandle:hover, StScrollBar StButton#hhandle:hover {
+  background-color: rgba(0, 0, 0, 0.6);
+}
+
+StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
+  background-color: rgba(0, 0, 0, 0.87);
+}
+
+#LookingGlassDialog StScrollBar StBin#trough, #overviewGroup StScrollBar StBin#trough {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#LookingGlassDialog StScrollBar StButton#vhandle, #overviewGroup StScrollBar StButton#vhandle, #LookingGlassDialog StScrollBar StButton#hhandle, #overviewGroup StScrollBar StButton#hhandle {
+  background-color: rgba(255, 255, 255, 0.5);
+}
+
+#LookingGlassDialog StScrollBar StButton#vhandle:hover, #overviewGroup StScrollBar StButton#vhandle:hover, #LookingGlassDialog StScrollBar StButton#hhandle:hover, #overviewGroup StScrollBar StButton#hhandle:hover {
+  background-color: rgba(255, 255, 255, 0.7);
+}
+
+#LookingGlassDialog StScrollBar StButton#vhandle:active, #overviewGroup StScrollBar StButton#vhandle:active, #LookingGlassDialog StScrollBar StButton#hhandle:active, #overviewGroup StScrollBar StButton#hhandle:active {
+  background-color: white;
+}
+
+.popup-menu .popup-sub-menu StScrollBar StBin#trough {
+  background-color: rgba(0, 0, 0, 0.15);
+}
+
+.popup-menu .popup-sub-menu StScrollBar StButton#vhandle, .popup-menu .popup-sub-menu StScrollBar StButton#hhandle {
+  background-color: rgba(0, 0, 0, 0.35);
+}
+
+.popup-menu .popup-sub-menu StScrollBar StButton#vhandle:hover, .popup-menu .popup-sub-menu StScrollBar StButton#hhandle:hover {
+  background-color: rgba(0, 0, 0, 0.45);
+}
+
+.popup-menu .popup-sub-menu StScrollBar StButton#vhandle:active, .popup-menu .popup-sub-menu StScrollBar StButton#hhandle:active {
+  background-color: rgba(0, 0, 0, 0.65);
+}
+
+/* Popovers/Menus */
+.popup-menu-boxpointer {
+  -arrow-rise: 6px;
+  background: none;
+}
+
+.popup-menu {
+  min-width: 12em;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.popup-menu .popup-menu-content {
+  padding: 6px;
+  margin: 0 3px 14px;
+  background-color: rgba(255, 255, 255, 0.97);
+  border-radius: 20px;
+  border: none;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+}
+
+.popup-menu .popup-menu-item {
+  spacing: 6px;
+  padding: 6px 12px;
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: transparent;
+  transition-duration: 100ms;
+  border-radius: 14px;
+  background-image: none;
+  border: none;
+}
+
+.popup-menu .popup-menu-item:checked {
+  font-weight: normal;
+  border-radius: 14px 14px 0 0;
+  border: none;
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.1) !important;
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-menu-item:checked:hover, .popup-menu .popup-menu-item:checked:focus, .popup-menu .popup-menu-item:checked.selected {
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  color: rgba(0, 0, 0, 0.85) !important;
+}
+
+.popup-menu .popup-menu-item:checked:active {
+  background-color: #dfdfdf !important;
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-menu-item:checked.selected:active {
+  background-color: rgba(0, 0, 0, 0.15) !important;
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-menu-item:checked:insensitive {
+  color: rgba(0, 0, 0, 0.35) !important;
+}
+
+.popup-menu .popup-menu-item:hover, .popup-menu .popup-menu-item:focus, .popup-menu .popup-menu-item.selected {
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  transition-duration: 0ms;
+}
+
+.popup-menu .popup-menu-item:active {
+  background-color: rgba(0, 0, 0, 0.26) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  transition-duration: 150ms;
+}
+
+.popup-menu .popup-menu-item.selected:active {
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-menu .popup-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.38) !important;
+}
+
+.popup-menu .popup-menu-item .toggle-switch:ltr {
+  margin-left: 4px;
+}
+
+.popup-menu .popup-menu-item .toggle-switch:rtl {
+  margin-right: 4px;
+}
+
+.popup-menu .popup-ornamented-menu-item:ltr {
+  padding-left: 6px;
+}
+
+.popup-menu .popup-ornamented-menu-item:rtl {
+  padding-right: 6px;
+}
+
+.popup-menu .popup-inactive-menu-item {
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-menu .popup-inactive-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.38) !important;
+}
+
+.popup-menu .popup-menu-arrow,
+.popup-menu .popup-menu-icon {
+  icon-size: 16px;
+}
+
+.popup-menu .popup-sub-menu {
+  margin: 0;
+  border-radius: 0 0 14px 14px;
+  border: none;
+  box-shadow: none;
+  background-image: none;
+  color: rgba(0, 0, 0, 0.75) !important;
+  background-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item {
+  margin: 0;
+  border-radius: 14px;
+  background-image: none;
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item:hover, .popup-menu .popup-sub-menu .popup-menu-item:focus, .popup-menu .popup-sub-menu .popup-menu-item.selected {
+  color: rgba(0, 0, 0, 0.85) !important;
+  background-color: rgba(0, 0, 0, 0.15) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item:active {
+  color: rgba(0, 0, 0, 0.85) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item.selected:active {
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.popup-menu .popup-sub-menu .popup-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.35) !important;
+}
+
+.popup-menu .popup-menu-ornament {
+  icon-size: 1.091em !important;
+  width: 1.091em;
+}
+
+.popup-menu .popup-separator-menu-item {
+  background: none;
+  border: none;
+}
+
+.popup-menu .popup-separator-menu-item .popup-separator-menu-item-separator {
+  height: 1px;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.popup-sub-menu .popup-menu .popup-separator-menu-item {
+  background-color: transparent;
+}
+
+.popup-sub-menu .popup-menu .popup-separator-menu-item:ltr {
+  margin-right: 2.5em;
+  margin-left: 1.5em;
+}
+
+.popup-sub-menu .popup-menu .popup-separator-menu-item:rtl {
+  margin-left: 2.5em;
+  margin-right: 1.5em;
+}
+
+.popup-sub-menu .popup-menu .popup-separator-menu-item .popup-separator-menu-item-separator {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.popup-menu.panel-menu {
+  margin-bottom: 1.75em;
+}
+
+.background-menu {
+  -boxpointer-gap: 0px;
+  -arrow-rise: 0px;
+}
+
+.app-menu {
+  max-width: 27.25em;
+}
+
+.app-menu .popup-inactive-menu-item:first-child > StLabel:ltr {
+  margin-right: 8px;
+}
+
+.app-menu .popup-inactive-menu-item:first-child > StLabel:rtl {
+  margin-left: 8px;
+}
+
+/* Date/Time Menu */
+#calendarArea {
+  padding: 6px 0 !important;
+}
+
+.calendar {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none;
+  box-shadow: none;
+  background: none;
+  text-shadow: none;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.datemenu-calendar-column {
+  spacing: 6px;
+  border: none;
+  padding: 0 !important;
+  margin: 0 !important;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.datemenu-calendar-column:hover, .datemenu-calendar-column:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.datemenu-calendar-column:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.datemenu-calendar-column:ltr {
+  margin-right: 6px !important;
+  margin-left: 12px !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+  border-left-width: 0;
+}
+
+.datemenu-calendar-column:rtl {
+  margin-left: 6px !important;
+  margin-right: 12px !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+  border-right-width: 0;
+}
+
+.datemenu-calendar-column .datemenu-displays-box {
+  spacing: 6px;
+}
+
+.datemenu-today-button {
+  min-height: 48px;
+  padding: 6px;
+  border-radius: 10px;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  background: none;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.datemenu-today-button .day-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+}
+
+.datemenu-today-button .date-label {
+  font-size: 18pt;
+  font-weight: 400;
+}
+
+.datemenu-today-button:hover, .datemenu-today-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.datemenu-today-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.calendar-month-label {
+  height: 20px;
+  margin: 2px;
+  padding: 6px 16px;
+  border-radius: 10px;
+  color: rgba(0, 0, 0, 0.6) !important;
+  background-color: transparent !important;
+  font-weight: bold;
+  text-align: center;
+  text-shadow: none;
+}
+
+.calendar-month-label:focus {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.08) !important;
+}
+
+.pager-button {
+  width: 28px !important;
+  height: 28px !important;
+  margin: 2px !important;
+  padding: 2px !important;
+  border-radius: 9999px;
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.pager-button:hover, .pager-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+  box-shadow: none !important;
+}
+
+.pager-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.calendar-change-month-back StIcon,
+.calendar-change-month-forward StIcon {
+  icon-size: 16px;
+}
+
+.calendar-change-month-back {
+  padding: 0 2px;
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-change-month-back:rtl {
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward {
+  padding: 0 2px;
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward:rtl {
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-day {
+  font-size: 9pt;
+  font-weight: 400;
+  text-align: center;
+  width: 3em !important;
+  height: 3em !important;
+  padding: 0 !important;
+  margin: 2px !important;
+  border-radius: 9999px;
+  color: rgba(0, 0, 0, 0.6) !important;
+  border: none !important;
+  font-feature-settings: "tnum";
+  text-shadow: none;
+  background-color: transparent !important;
+}
+
+.calendar-day:hover, .calendar-day:focus {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  box-shadow: none;
+}
+
+.calendar-day:active {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.26) !important;
+  border: none !important;
+}
+
+.calendar-day:selected {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.26) !important;
+  border: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.calendar-day.calendar-weekend {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.calendar-day-heading {
+  width: 24px !important;
+  height: 18px !important;
+  margin-top: 2px !important;
+  padding: 6px 0 0 !important;
+  border-radius: 9999px;
+  background-color: transparent !important;
+  color: rgba(0, 0, 0, 0.38) !important;
+  font-size: 9pt;
+  font-weight: 400;
+  font-weight: bold;
+  text-align: center;
+}
+
+.calendar-day {
+  border-width: 0;
+}
+
+.calendar-day-top {
+  border-top-width: 0;
+}
+
+.calendar-day-left {
+  border-left-width: 0;
+}
+
+.calendar-nonwork-day {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.calendar-today {
+  font-weight: bold !important;
+  color: white !important;
+  background-color: #1A73E8 !important;
+  border: none;
+}
+
+.calendar-today:hover, .calendar-today:focus {
+  background-color: #287ce9 !important;
+  color: white !important;
+}
+
+.calendar-today:active, .calendar-today:selected {
+  background-color: #1A73E8 !important;
+  color: white !important;
+}
+
+.calendar-today:active:hover, .calendar-today:active:focus, .calendar-today:selected:hover, .calendar-today:selected:focus {
+  background-color: #287ce9 !important;
+  color: white !important;
+}
+
+.calendar-day-with-events {
+  color: rgba(0, 0, 0, 0.38);
+  background-image: url("assets/calendar-today.svg");
+  background-size: contain;
+}
+
+.calendar-day-with-events.calendar-work-day {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: bold;
+}
+
+.calendar-other-month {
+  color: rgba(0, 0, 0, 0.26) !important;
+  font-weight: normal;
+}
+
+.calendar-other-month.calendar-weekend {
+  color: rgba(0, 0, 0, 0.26) !important;
+}
+
+.calendar-week-number {
+  margin: 6px !important;
+  padding: 0 8px !important;
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.04);
+  color: rgba(0, 0, 0, 0.38);
+  font-size: 8.25pt;
+  font-weight: bold;
+  text-align: center;
+  text-shadow: none;
+  font-feature-settings: "tnum";
+}
+
+.world-clocks-button,
+.weather-button,
+.events-button,
+.popup-menu .message {
+  padding: 6px 12px;
+  border-radius: 10px;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  color: rgba(0, 0, 0, 0.6);
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+.world-clocks-button:hover, .world-clocks-button:focus,
+.weather-button:hover,
+.weather-button:focus,
+.events-button:hover,
+.popup-menu .message:hover,
+.events-button:focus,
+.popup-menu .message:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.world-clocks-button:active,
+.weather-button:active,
+.events-button:active,
+.popup-menu .message:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.world-clocks-header,
+.weather-header,
+.message-list-section-title,
+.events-section-title,
+.events-title {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: bold;
+  margin-bottom: 3px;
+  text-shadow: none;
+}
+
+.weather-grid,
+.world-clocks-grid {
+  spacing-rows: 8px;
+  spacing-columns: 16px;
+}
+
+.world-clocks-header,
+.weather-header,
+.events-section-title {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: bold;
+  font-size: 1em;
+}
+
+.events-button .events-box, .popup-menu .message .events-box {
+  spacing: 6px;
+}
+
+.events-button .events-list, .popup-menu .message .events-list {
+  color: rgba(0, 0, 0, 0.6);
+  spacing: 12px;
+  text-shadow: none;
+}
+
+.events-button .event-time, .popup-menu .message .event-time {
+  color: rgba(0, 0, 0, 0.26);
+  font-feature-settings: "tnum";
+}
+
+.world-clocks-button .world-clocks-city {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: normal;
+  font-size: 1em;
+}
+
+.world-clocks-button .world-clocks-time {
+  color: rgba(0, 0, 0, 0.38);
+  font-feature-settings: "tnum";
+  font-weight: bold;
+  font-size: 1em;
+}
+
+.world-clocks-button .world-clocks-time:ltr {
+  text-align: right;
+}
+
+.world-clocks-button .world-clocks-time:rtl {
+  text-align: left;
+}
+
+.world-clocks-button .world-clocks-timezone {
+  color: rgba(0, 0, 0, 0.38);
+  font-feature-settings: "tnum";
+  font-size: 1em;
+}
+
+.weather-button .weather-box {
+  spacing: 12px;
+}
+
+.weather-button .weather-header-box {
+  spacing: 8px;
+}
+
+.weather-button .weather-header.location {
+  font-weight: normal;
+  color: rgba(0, 0, 0, 0.38);
+  font-size: 0.9em;
+}
+
+.weather-button .weather-forecast-icon {
+  icon-size: 32px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.weather-button .weather-forecast-time {
+  color: rgba(0, 0, 0, 0.38);
+  font-size: 0.8em;
+  font-feature-settings: "tnum";
+  font-weight: normal;
+  padding-top: 0.2em;
+  padding-bottom: 0.4em;
+}
+
+.weather-button .weather-forecast-temp {
+  font-weight: bold;
+  color: rgba(0, 0, 0, 0.52);
+  text-shadow: none;
+}
+
+/* Message List */
+.message-list {
+  width: 29em;
+  color: rgba(0, 0, 0, 0.6);
+  border: solid transparent;
+}
+
+.message-list:ltr {
+  margin-left: 0;
+  margin-right: 0;
+  padding-right: 0;
+  border-right-width: 0;
+}
+
+.message-list:rtl {
+  margin-right: 0;
+  margin-left: 0;
+  padding-left: 0;
+  border-left-width: 0;
+}
+
+.message-list .message-list-placeholder {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.message-list .message-list-placeholder > StIcon {
+  icon-size: 96px;
+  margin-bottom: 12px;
+  -st-icon-style: symbolic;
+}
+
+.message-list-sections {
+  spacing: 6px;
+}
+
+.message-list-sections:ltr {
+  margin-right: 4px;
+  padding-left: 6px;
+}
+
+.message-list-sections:rtl {
+  margin-left: 4px;
+  padding-right: 6px;
+}
+
+.message-list-section,
+.message-list-section-list {
+  spacing: 6px;
+}
+
+.message-list-controls {
+  margin: 8px 16px 0;
+  padding: 4px;
+  spacing: 12px;
+}
+
+.message-list-controls .dnd-button {
+  border-width: 2px;
+  border-color: transparent;
+  border-radius: 32px;
+  border-style: solid;
+}
+
+.message-list-controls .dnd-button:focus {
+  border-color: rgba(26, 115, 232, 0.6);
+}
+
+.message {
+  border-radius: 10px;
+  padding: 0;
+  margin: 0;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.32);
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(255, 255, 255, 0.96);
+}
+
+.message:hover, .message:focus, .message:active {
+  background-color: #FFFFFF;
+}
+
+.popup-menu .message {
+  border: 1px solid transparent;
+  border-left: none;
+  border-bottom: none;
+  padding: 0;
+  margin: 0;
+  box-shadow: none;
+  margin: 4px;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.message:ltr {
+  padding-right: -2px;
+}
+
+.message:rtl {
+  padding-left: -2px;
+}
+
+.message .message-header {
+  padding: 0 0.409em;
+  margin: 6px;
+  margin-bottom: 0;
+  spacing: 6px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.message .message-header .message-source-icon {
+  icon-size: 1.091em;
+  -st-icon-style: symbolic;
+}
+
+.message .message-header .message-header-content {
+  spacing: 6px;
+  min-height: 1.637em;
+  padding-bottom: 6px;
+}
+
+.message .message-header .message-header-content .message-source-title {
+  font-weight: bold;
+}
+
+.message .message-header .message-header-content .event-time {
+  color: rgba(0, 0, 0, 0.38);
+  padding-bottom: 0.068em;
+}
+
+.message .message-header .message-header-content .event-time:ltr {
+  text-align: right;
+}
+
+.message .message-header .message-header-content .event-time:rtl {
+  text-align: left;
+}
+
+.message .message-header .message-expand-button,
+.message .message-header .message-close-button {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.04);
+  padding: 4px;
+}
+
+.message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.message .message-header .message-expand-button:active, .message .message-header .message-expand-button:active:hover,
+.message .message-header .message-close-button:active,
+.message .message-header .message-close-button:active:hover {
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive {
+  background-color: transparent;
+}
+
+.message .message-header .message-expand-button {
+  padding: 4px;
+}
+
+.message .message-header .message-expand-button:ltr {
+  margin-right: 6px;
+}
+
+.message .message-header .message-expand-button:rtl {
+  margin-left: 6px;
+}
+
+.message .message-box {
+  padding: 6px;
+  margin: 6px;
+  margin-top: 0;
+  spacing: 6px;
+}
+
+.message .message-box .message-icon {
+  icon-size: 48px;
+  -st-icon-style: symbolic;
+}
+
+.message .message-box .message-icon:ltr {
+  margin-right: 6px;
+}
+
+.message .message-box .message-icon:rtl {
+  margin-left: 6px;
+}
+
+.message .message-box .message-icon.message-themed-icon {
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.12);
+  icon-size: 16px;
+  min-width: 48px;
+  min-height: 48px;
+}
+
+.message .message-box:first-child {
+  margin-top: 12px;
+}
+
+.message .message-box .message-content {
+  spacing: 4px;
+}
+
+.message .message-box .message-content .message-title {
+  font-weight: bold;
+}
+
+.url-highlighter {
+  link-color: #1A73E8;
+}
+
+/* Media Controls */
+.message-media-control {
+  margin: 4px 3px !important;
+  padding: 0 12px !important;
+  border-radius: 9999px;
+  color: rgba(0, 0, 0, 0.6);
+  border: none;
+}
+
+.message-media-control:hover, .message-media-control:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.message-media-control:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.message-media-control:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.message-media-control StIcon {
+  icon-size: 16px;
+}
+
+.media-message .message-icon {
+  border-radius: 6px !important;
+}
+
+.media-message .message-icon.message-themed-icon {
+  icon-size: 32px !important;
+}
+
+.candidate-popup-boxpointer {
+  -arrow-border-radius: 2px;
+  -arrow-background-color: transparent;
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 64px;
+  -arrow-rise: 12px;
+}
+
+.candidate-popup-content {
+  background-color: #FFFFFF;
+  border-radius: 11px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+  margin: 3px 10px 13px;
+  padding: 6px;
+  spacing: 6px;
+  border: none;
+}
+
+.candidate-index {
+  padding: 0 0.5em 0 0;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.candidate-box:selected .candidate-index {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.candidate-box {
+  padding: 0.3em 0.5em 0.3em 0.5em;
+  margin-right: 3px;
+  border-radius: 5px;
+}
+
+.candidate-box:hover {
+  background-color: rgba(0, 0, 0, 0.08);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.candidate-box:active {
+  background-color: rgba(0, 0, 0, 0.26);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.candidate-box:selected {
+  background-color: #1A73E8;
+  color: white;
+}
+
+.candidate-box:last-child {
+  margin-right: 0;
+}
+
+.candidate-page-button-box {
+  height: 2em;
+}
+
+.vertical .candidate-page-button-box {
+  padding-top: 0.5em;
+}
+
+.horizontal .candidate-page-button-box {
+  padding-left: 0.5em;
+}
+
+.candidate-page-button {
+  padding: 4px 8px;
+}
+
+.candidate-page-button-previous {
+  border-radius: 5px;
+  border-right-width: 0;
+}
+
+.candidate-page-button-next {
+  border-radius: 5px;
+  margin-left: 2px;
+}
+
+.candidate-page-button-icon {
+  icon-size: 1em;
+}
+
+.quick-settings {
+  padding: 18px !important;
+  border-radius: 38px !important;
+  margin-top: 3px !important;
+  border: none;
+}
+
+.quick-settings .icon-button, .quick-settings .background-app-item .close-button, .background-app-item .quick-settings .close-button, .quick-settings .message .message-header .message-expand-button, .message .message-header .quick-settings .message-expand-button,
+.quick-settings .message .message-header .message-close-button,
+.message .message-header .quick-settings .message-close-button, .quick-settings .button {
+  padding: 12px;
+}
+
+.quick-settings .icon-button > StIcon, .quick-settings .background-app-item .close-button > StIcon, .background-app-item .quick-settings .close-button > StIcon, .quick-settings .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings .message-expand-button > StIcon,
+.quick-settings .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings .message-close-button > StIcon, .quick-settings .button > StIcon {
+  icon-size: 16px;
+}
+
+.quick-settings-grid {
+  spacing-rows: 12px;
+  spacing-columns: 12px;
+}
+
+.quick-toggle, .quick-menu-toggle {
+  border-radius: 9999px;
+  min-width: 12em;
+  max-width: 12em;
+  min-height: 44px;
+  border: none;
+}
+
+.quick-toggle {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  /* Move padding into the box; this is to allow menu arrows
+     to extend to the border */
+}
+
+.quick-toggle:hover {
+  background-color: rgba(0, 0, 0, 0.12) !important;
+}
+
+.quick-toggle:active {
+  background-color: rgba(0, 0, 0, 0.24) !important;
+}
+
+.quick-toggle:checked {
+  background-color: #1A73E8 !important;
+  color: white !important;
+}
+
+.quick-toggle:checked:hover {
+  background-color: rgba(24, 106, 214, 0.987) !important;
+  color: white !important;
+}
+
+.quick-toggle:checked:active {
+  background-color: rgba(22, 96, 195, 0.974) !important;
+  color: white !important;
+}
+
+.quick-toggle > StBoxLayout {
+  spacing: 6px;
+}
+
+.quick-toggle.button {
+  padding: 0;
+}
+
+.quick-toggle > StBoxLayout {
+  padding: 0 12px;
+}
+
+.quick-toggle:ltr > StBoxLayout {
+  padding-left: 15px;
+}
+
+.quick-toggle:rtl > StBoxLayout {
+  padding-right: 15px;
+}
+
+.quick-toggle .quick-toggle-title {
+  font-weight: bold;
+}
+
+.quick-toggle StBoxLayout > .quick-toggle-subtitle {
+  font-weight: normal;
+  font-size: 12px;
+}
+
+.quick-toggle .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-menu-toggle .quick-toggle {
+  min-width: auto;
+  max-width: auto;
+}
+
+.quick-menu-toggle .quick-toggle:ltr {
+  border-radius: 9999px 0 0 9999px;
+}
+
+.quick-menu-toggle .quick-toggle:ltr > StBoxLayout {
+  padding-right: 0;
+}
+
+.quick-menu-toggle .quick-toggle:rtl {
+  border-radius: 0 9999px 9999px 0;
+}
+
+.quick-menu-toggle .quick-toggle:rtr > StBoxLayout {
+  padding-left: 0;
+}
+
+.quick-menu-toggle .quick-toggle:ltr:last-child {
+  border-radius: 9999px;
+}
+
+.quick-menu-toggle .quick-toggle:rtl:last-child {
+  border-radius: 9999px;
+}
+
+.quick-menu-toggle .quick-toggle-arrow {
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  padding: 6px 10.5px;
+  border: none !important;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:hover {
+  background-color: rgba(0, 0, 0, 0.12) !important;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:active {
+  background-color: rgba(0, 0, 0, 0.26) !important;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:checked {
+  background-color: #1A73E8 !important;
+  color: white;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:checked:hover {
+  background-color: rgba(24, 106, 214, 0.987) !important;
+  color: white;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:checked:active {
+  background-color: rgba(22, 96, 195, 0.974) !important;
+  color: white;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:ltr {
+  border-radius: 0 9999px 9999px 0;
+}
+
+.quick-menu-toggle .quick-toggle-arrow:rtl {
+  border-radius: 9999px 0 0 9999px;
+}
+
+.quick-slider > StBoxLayout {
+  spacing: 6px;
+}
+
+.quick-slider .icon-button, .quick-slider .background-app-item .close-button, .background-app-item .quick-slider .close-button, .quick-slider .message .message-header .message-expand-button, .message .message-header .quick-slider .message-expand-button,
+.quick-slider .message .message-header .message-close-button,
+.message .message-header .quick-slider .message-close-button {
+  padding: 9px;
+}
+
+.quick-slider .slider-bin {
+  min-height: 16px;
+  padding: 6px;
+  border-radius: 9999px;
+}
+
+.quick-slider .slider-bin:focus {
+  color: #1A73E8;
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.quick-slider .slider-bin:focus:active {
+  color: white;
+}
+
+.quick-slider .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-toggle-menu {
+  border-radius: 30px !important;
+  padding: 12px;
+  margin: 12px 21px 0;
+  background-color: white !important;
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+.quick-toggle-menu:insensitive {
+  background-color: white !important;
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+.quick-toggle-menu .popup-menu-item {
+  padding: 8px !important;
+  border-radius: 9999px !important;
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+.quick-toggle-menu .popup-menu-item StLabel {
+  color: rgba(0, 0, 0, 0.65);
+}
+
+.quick-toggle-menu .popup-menu-item:focus, .quick-toggle-menu .popup-menu-item:hover, .quick-toggle-menu .popup-menu-item.selected {
+  color: rgba(0, 0, 0, 0.75) !important;
+  background-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.quick-toggle-menu .popup-menu-item:active {
+  color: rgba(0, 0, 0, 0.75) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+
+.quick-toggle-menu .popup-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.25) !important;
+}
+
+.quick-toggle-menu .popup-menu-item > StIcon {
+  -st-icon-style: symbolic;
+  icon-size: 1.091em;
+}
+
+.quick-toggle-menu .popup-menu-item > :first-child:ltr {
+  padding-left: 10px !important;
+}
+
+.quick-toggle-menu .popup-menu-item > :first-child:rtl {
+  padding-right: 10px !important;
+}
+
+.quick-toggle-menu .popup-menu-item .popup-separator-menu-item-separator {
+  margin: 6px 18px 6px 0 !important;
+  padding: 0 !important;
+  background-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.quick-toggle-menu .header {
+  spacing-rows: 3px;
+  spacing-columns: 12px;
+  padding-bottom: 12px;
+}
+
+.quick-toggle-menu .header .icon {
+  icon-size: 24px;
+  border-radius: 9999px;
+  padding: 9px;
+  background-color: rgba(0, 0, 0, 0.08) !important;
+}
+
+.quick-toggle-menu .header .icon.active {
+  background-color: #1A73E8 !important;
+  color: white !important;
+}
+
+.quick-settings-system-item > StBoxLayout {
+  spacing: 12px;
+}
+
+.quick-settings-system-item .icon-button, .quick-settings-system-item .background-app-item .close-button, .background-app-item .quick-settings-system-item .close-button, .quick-settings-system-item .message .message-header .message-expand-button, .message .message-header .quick-settings-system-item .message-expand-button,
+.quick-settings-system-item .message .message-header .message-close-button,
+.message .message-header .quick-settings-system-item .message-close-button {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.quick-settings-system-item .icon-button:hover, .quick-settings-system-item .background-app-item .close-button:hover, .background-app-item .quick-settings-system-item .close-button:hover, .quick-settings-system-item .message .message-header .message-expand-button:hover, .message .message-header .quick-settings-system-item .message-expand-button:hover,
+.quick-settings-system-item .message .message-header .message-close-button:hover,
+.message .message-header .quick-settings-system-item .message-close-button:hover {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.quick-settings-system-item .icon-button:active, .quick-settings-system-item .background-app-item .close-button:active, .background-app-item .quick-settings-system-item .close-button:active, .quick-settings-system-item .message .message-header .message-expand-button:active, .message .message-header .quick-settings-system-item .message-expand-button:active,
+.quick-settings-system-item .message .message-header .message-close-button:active,
+.message .message-header .quick-settings-system-item .message-close-button:active {
+  background-color: rgba(0, 0, 0, 0.24);
+}
+
+.quick-settings-system-item .icon-button > StIcon, .quick-settings-system-item .background-app-item .close-button > StIcon, .background-app-item .quick-settings-system-item .close-button > StIcon, .quick-settings-system-item .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings-system-item .message-expand-button > StIcon,
+.quick-settings-system-item .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings-system-item .message-close-button > StIcon {
+  -st-icon-style: symbolic;
+}
+
+.quick-settings-system-item .power-item {
+  min-height: 0;
+  min-width: 0;
+}
+
+.quick-settings-system-item .power-item:insensitive {
+  color: rgba(0, 0, 0, 0.6);
+  background-color: rgba(0, 0, 0, 0.04);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+  background-color: transparent;
+}
+
+.nm-network-item .wireless-secure-icon {
+  icon-size: 8px;
+}
+
+.bt-device-item .popup-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  text-align: center;
+  padding: 2em 4em;
+}
+
+.device-subtitle {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.keyboard-brightness-level {
+  spacing: 6px;
+  background-color: #FFFFFF !important;
+  color: rgba(0, 0, 0, 0.6) !important;
+}
+
+.background-apps-quick-toggle {
+  min-height: 44px;
+  background-color: transparent;
+}
+
+.background-apps-quick-toggle StIcon {
+  icon-size: 16px !important;
+}
+
+.background-app-item .popup-menu-icon {
+  icon-size: 32px !important;
+  -st-icon-style: regular !important;
+}
+
+.background-app-item .close-button {
+  padding: 6px;
+}
+
+.background-app-item.popup-inactive-menu-item {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+/* Notifications & Message Tray */
+.notification-banner {
+  min-height: 64px;
+  width: 34em;
+  font-size: 1em;
+  margin: 6px;
+  border-radius: 20px;
+  border-left: none;
+  border-bottom: none;
+}
+
+.notification-buttons-bin {
+  background-color: transparent;
+  padding: 0;
+  spacing: 0;
+  margin: 0;
+}
+
+.notification-button {
+  min-height: 40px;
+  padding: 3px 16px;
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.6);
+  font-weight: 500;
+  border: none;
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.popup-menu .notification-button {
+  padding: 0 16px;
+}
+
+.notification-button:first-child:ltr {
+  border-radius: 0 0 0 20px;
+}
+
+.notification-button:last-child:ltr {
+  border-radius: 0 0 20px;
+  margin-right: 0 !important;
+}
+
+.notification-button:first-child:rtl {
+  border-radius: 0 0 20px;
+}
+
+.notification-button:last-child:rtl {
+  border-radius: 0 0 0 20px;
+  margin-left: 0 !important;
+}
+
+.notification-button:first-child:last-child {
+  border-radius: 0 0 20px 20px;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.notification-button:focus {
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.6);
+  box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.08);
+}
+
+.notification-button:hover {
+  background-color: rgba(0, 0, 0, 0.08);
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.notification-button:active, .notification-button:checked {
+  background-color: rgba(0, 0, 0, 0.26);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.notification-button:insensitive {
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.popup-menu .notification-button:first-child:ltr {
+  border-radius: 0 0 0 10px;
+}
+
+.popup-menu .notification-button:last-child:ltr {
+  border-radius: 0 0 10px;
+}
+
+.popup-menu .notification-button:first-child:rtl {
+  border-radius: 0 0 10px;
+}
+
+.popup-menu .notification-button:last-child:rtl {
+  border-radius: 0 0 0 10px;
+}
+
+.popup-menu .notification-button:first-child:last-child {
+  border-radius: 0 0 10px 10px;
+}
+
+.hotplug-notification-item {
+  padding: 2px 10px;
+}
+
+.hotplug-notification-item-icon {
+  icon-size: 24px;
+  padding: 0 4px;
+}
+
+/* Modal Dialogs */
+.headline {
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.modal-dialog {
+  border-radius: 26px;
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #FFFFFF;
+  border: 0 none rgba(0, 0, 0, 0.15);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+}
+
+.modal-dialog .modal-dialog-content-box {
+  margin: 32px 40px;
+  spacing: 32px;
+  max-width: 28em;
+  background-color: #FFFFFF;
+}
+
+.modal-dialog .modal-dialog-linked-button {
+  min-height: 40px;
+  padding: 0 16px;
+}
+
+/* End Session Dialog */
+.end-session-dialog {
+  width: 30em;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child {
+  color: white !important;
+  background-color: #E53935;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:hover {
+  color: white !important;
+  background-color: #ea615e;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:active {
+  color: white !important;
+  background-color: #e2231e;
+}
+
+.end-session-dialog .end-session-dialog-battery-warning,
+.end-session-dialog .dialog-list-title {
+  color: #FFD600;
+}
+
+/* Message Dialog */
+.message-dialog-content {
+  spacing: 18px;
+}
+
+.message-dialog-content .message-dialog-title {
+  text-align: center;
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-title.lightweight {
+  font-size: 13pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-description {
+  text-align: center;
+}
+
+/* Dialog List */
+.dialog-list {
+  spacing: 18px;
+}
+
+.dialog-list .dialog-list-title {
+  text-align: center;
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-scrollview {
+  max-height: 200px;
+}
+
+.dialog-list .dialog-list-box {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-title {
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-description {
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+/* Run Dialog */
+.run-dialog .modal-dialog-content-box {
+  margin-top: 24px;
+  margin-bottom: 14px;
+}
+
+.run-dialog .run-dialog-entry {
+  width: 20em;
+}
+
+.run-dialog .run-dialog-description {
+  font-size: 12pt;
+  font-weight: 400;
+  text-align: center;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+/* Password or Authentication Dialog */
+.prompt-dialog {
+  width: 28em;
+}
+
+.prompt-dialog .modal-dialog-linked-button:first-child {
+  color: #E53935;
+}
+
+.prompt-dialog .modal-dialog-linked-button:first-child:active {
+  color: white !important;
+  background-color: #E53935;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child {
+  color: white !important;
+  background-color: #1A73E8;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:hover {
+  color: white !important;
+  background-color: #448dec;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:active {
+  color: white !important;
+  background-color: #1567d3;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:insensitive {
+  color: rgba(26, 115, 232, 0.5) !important;
+  background-color: rgba(26, 115, 232, 0.15);
+}
+
+.prompt-dialog .modal-dialog-content-box {
+  margin-bottom: 24px;
+  background-color: #FFFFFF;
+}
+
+.prompt-dialog-password-grid {
+  spacing-rows: 8px;
+  spacing-columns: 4px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry {
+  width: auto;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:ltr {
+  margin-left: 20px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:rtl {
+  margin-right: 20px;
+}
+
+.prompt-dialog-password-layout {
+  spacing: 8px;
+}
+
+.prompt-dialog-password-entry {
+  width: 20em;
+}
+
+.prompt-dialog-error-label,
+.prompt-dialog-info-label,
+.prompt-dialog-null-label {
+  text-align: center;
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.prompt-dialog-error-label {
+  color: #FFD600;
+}
+
+/* Polkit Dialog */
+.polkit-dialog-user-layout {
+  text-align: center;
+  spacing: 8px;
+  margin-bottom: 6px;
+}
+
+.polkit-dialog-user-layout .polkit-dialog-user-root-label {
+  color: #FFD600;
+}
+
+/* Audio selection dialog */
+.audio-device-selection-dialog .modal-dialog-content-box {
+  margin-bottom: 28px;
+}
+
+.audio-device-selection-dialog .audio-selection-box {
+  spacing: 20px;
+}
+
+.audio-selection-device {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 10px;
+}
+
+.audio-selection-device:active, .audio-selection-device:hover, .audio-selection-device:focus {
+  background-color: #1A73E8;
+}
+
+.audio-selection-device-box {
+  padding: 20px;
+  spacing: 20px;
+}
+
+.audio-selection-device-icon {
+  icon-size: 64px;
+}
+
+/* Welcome dialog */
+.welcome-dialog-image {
+  background-image: url("resource:///org/gnome/shell/theme/gnome-shell-start.svg");
+  background-size: contain;
+  /* Reasonable maximum dimensions */
+  height: 300px;
+  width: 300px;
+}
+
+/* Network Dialogs */
+.nm-dialog {
+  max-height: 34em;
+  min-height: 31em;
+  min-width: 32em;
+}
+
+.nm-dialog-content {
+  spacing: 20px;
+  padding: 24px;
+}
+
+.nm-dialog-airplane-box {
+  spacing: 12px;
+}
+
+.nm-dialog-airplane-headline {
+  font-weight: bold;
+  text-align: center;
+}
+
+.nm-dialog-airplane-text {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.nm-dialog-header {
+  font-weight: bold;
+}
+
+.nm-dialog-header-icon {
+  icon-size: 32px;
+}
+
+.nm-dialog-header-hbox {
+  spacing: 10px;
+}
+
+.nm-dialog-scroll-view {
+  border: none;
+  background-color: rgba(0, 0, 0, 0.08);
+  border-radius: 10px;
+  padding: 12px;
+  padding-right: 0;
+}
+
+.nm-dialog-item {
+  font-size: 1em;
+  border-bottom: none;
+  border-radius: 4px;
+  padding: 12px;
+  spacing: 0px;
+}
+
+.nm-dialog-item:hover, .nm-dialog-item:focus {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.nm-dialog-item:active {
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.nm-dialog-item:selected {
+  background-color: #1A73E8;
+  color: white;
+}
+
+.nm-dialog-icon {
+  icon-size: 16px;
+}
+
+.nm-dialog-icons {
+  spacing: 12px;
+}
+
+.no-networks-label {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.no-networks-box {
+  spacing: 6px;
+}
+
+/* OSD */
+.osd-window {
+  text-align: center;
+  font-weight: bold;
+  spacing: 12px;
+  padding: 12px 18px;
+  margin-bottom: 8em;
+  border-radius: 9999px;
+}
+
+.osd-window > * {
+  spacing: 8px;
+}
+
+.osd-window StIcon {
+  icon-size: 32px;
+}
+
+.osd-window .osd-monitor-label {
+  font-size: 3em;
+}
+
+.osd-window StLabel:ltr {
+  margin-right: 6px;
+}
+
+.osd-window StLabel:rtl {
+  margin-left: 6px;
+}
+
+.osd-window .level {
+  height: 4px;
+  min-width: 160px;
+  margin-bottom: 4px;
+  -barlevel-height: 4px;
+  -barlevel-background-color: rgba(26, 115, 232, 0.3);
+  -barlevel-active-background-color: #1A73E8;
+  -barlevel-overdrive-color: #E53935;
+  -barlevel-overdrive-separator-width: 3px;
+  -barlevel-border-width: 0;
+}
+
+.osd-window .level:first-child {
+  margin-bottom: 0px;
+}
+
+.osd-window .level:ltr {
+  margin-right: 6px;
+}
+
+.osd-window .level:rtl {
+  margin-left: 6px;
+}
+
+.osd-monitor-label {
+  border-radius: 18px;
+  font-size: 3em;
+  font-weight: bold;
+  margin: 12px;
+  text-align: center;
+  min-width: 1.3em;
+}
+
+/* Pad OSD */
+.pad-osd-window {
+  padding: 32px;
+  background-color: rgba(0, 0, 0, 0.8);
+  border: none;
+}
+
+.pad-osd-window .pad-osd-title-box {
+  spacing: 12px;
+}
+
+.pad-osd-window .pad-osd-title-menu-box {
+  spacing: 6px;
+}
+
+.combo-box-label {
+  width: 15em;
+}
+
+.resize-popup {
+  border-radius: 18px;
+}
+
+/* App Switcher */
+.switcher-popup {
+  padding: 8px;
+  spacing: 24px;
+}
+
+.switcher-list {
+  border-radius: 22px;
+}
+
+.switcher-list .item-box {
+  padding: 8px;
+  border-radius: 10px;
+  border: none;
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.switcher-list .item-box:outlined {
+  background-color: rgba(0, 0, 0, 0.08);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.switcher-list .item-box:selected {
+  background-color: #1A73E8;
+  color: white;
+}
+
+.switcher-list .thumbnail-box {
+  padding: 2px;
+  spacing: 6px;
+}
+
+.switcher-list .thumbnail {
+  width: 256px;
+}
+
+.switcher-list .separator {
+  width: 1px;
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.switcher-list .switcher-list-item-container {
+  spacing: 12px;
+}
+
+.switcher-arrow {
+  border-color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.switcher-arrow:highlighted {
+  color: white;
+}
+
+.input-source-switcher-symbol {
+  font-size: 34pt;
+  width: 96px;
+  height: 96px;
+}
+
+.cycler-highlight {
+  border: 5px solid #1A73E8;
+}
+
+/* Workspace Switcher */
+.workspace-switcher-group {
+  padding: 12px;
+}
+
+.workspace-switcher-container {
+  border-radius: 18px;
+}
+
+.workspace-switcher {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  spacing: 12px;
+}
+
+.ws-switcher-box {
+  height: 50px;
+  background-size: 32px;
+  border: none;
+  background: rgba(0, 0, 0, 0.08);
+  border-radius: 10px;
+}
+
+.ws-switcher-active-up,
+.ws-switcher-active-down,
+.ws-switcher-active-left,
+.ws-switcher-active-right {
+  height: 52px;
+  background-color: #1A73E8;
+  border: none;
+  border-radius: 13px;
+  color: white;
+}
+
+/* Top Bar */
+#panel {
+  font-weight: bold;
+  font-feature-settings: "tnum";
+  padding: 0 !important;
+  transition-duration: 250ms;
+  height: 38px;
+  border: none;
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.65);
+  margin: 3px;
+  border-radius: 9999px;
+}
+
+#panel.unlock-screen, #panel.login-screen, #panel:overview {
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-corner, #panel.login-screen .panel-corner, #panel:overview .panel-corner {
+  -panel-corner-opacity: 0;
+}
+
+#panel .panel-corner {
+  -panel-corner-radius: 0;
+  -panel-corner-background-color: rgba(33, 33, 33, 0.65);
+  -panel-corner-border-width: 0;
+  -panel-corner-border-color: transparent;
+  -panel-corner-opacity: 1;
+  transition-duration: 250ms;
+}
+
+#panel .panel-button#panelActivities {
+  -natural-hpadding: 15px;
+}
+
+#panel .panel-button#panelActivities StBoxLayout {
+  spacing: 6px;
+}
+
+#panel .panel-button#panelActivities .workspace-dot {
+  border-radius: 9999px;
+  min-width: 8px;
+  min-height: 8px;
+  background-color: white;
+}
+
+#panel .panel-button {
+  font-weight: bold;
+  color: white;
+  -natural-hpadding: 11px;
+  -minimum-hpadding: 11px;
+  transition-duration: 150ms;
+  border: 3px solid transparent;
+  border-radius: 9999px;
+  margin: 0;
+}
+
+#panel .panel-button.clock-display {
+  -natural-hpadding: 0 !important;
+  -minimum-hpadding: 0 !important;
+  padding: 0 !important;
+  spacing: 0 !important;
+}
+
+#panel .panel-button.clock-display .clock-display-box {
+  spacing: 0;
+}
+
+#panel .panel-button.clock-display .clock {
+  border-radius: 9999px;
+  padding: 0 12px !important;
+}
+
+#panel .panel-button:hover {
+  background-color: transparent;
+  box-shadow: inset 0 0 0 1000px rgba(255, 255, 255, 0.12);
+}
+
+#panel .panel-button:hover.clock-display {
+  box-shadow: none;
+  background-color: transparent;
+}
+
+#panel .panel-button:hover.clock-display .clock {
+  box-shadow: inset 0 0 0 1000px rgba(255, 255, 255, 0.12);
+}
+
+#panel .panel-button:active, #panel .panel-button:overview, #panel .panel-button:focus, #panel .panel-button:checked {
+  background-color: transparent;
+  box-shadow: inset 0 0 0 1000px rgba(255, 255, 255, 0.3);
+}
+
+#panel .panel-button:active.clock-display, #panel .panel-button:overview.clock-display, #panel .panel-button:focus.clock-display, #panel .panel-button:checked.clock-display {
+  box-shadow: none;
+  background-color: transparent;
+}
+
+#panel .panel-button:active.clock-display .clock, #panel .panel-button:overview.clock-display .clock, #panel .panel-button:focus.clock-display .clock, #panel .panel-button:checked.clock-display .clock {
+  box-shadow: inset 0 0 0 1000px rgba(255, 255, 255, 0.3);
+}
+
+#panel .panel-button .system-status-icon {
+  icon-size: 16px;
+  padding: 6px;
+  margin: 0;
+}
+
+#panel .panel-button .appindicator-trayicons-box {
+  margin: 0 6px;
+}
+
+#panel .panel-button .app-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button {
+  border: 0 none transparent !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  -natural-hpadding: 3px !important;
+  -minimum-hpadding: 3px !important;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .panel-status-menu-box,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .panel-status-menu-box,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .panel-status-menu-box {
+  spacing: 0;
+  padding: 0;
+  margin: 0;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon {
+  border-radius: 9999px;
+  width: 33px;
+  margin: 3px 0;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:hover,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  box-shadow: none;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:active, #panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:overview, #panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:focus, #panel Gjs_arcmenu_arcmenu_com_menuButton_Arc_Menu_MenuButton.panel-button .arc-menu-icon:checked,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:active,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:overview,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:focus,
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenu_MenuButton.panel-button .arc-menu-icon:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: none;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button {
+  border-radius: 9999px;
+  width: 33px;
+  margin: 3px 0;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  box-shadow: none;
+}
+
+#panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:active, #panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:overview, #panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:focus, #panel Gjs_arcmenu_arcmenu_com_menuButton_ArcMenuMenuButton.panel-button .arcmenu-menu-button:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: none;
+}
+
+#panel Gjs_status_keyboard_InputSourceIndicator.panel-button,
+#panel Gjs_appindicatorsupport_rgcjonas_gmail_com_indicatorStatusIcon_IndicatorStatusIcon.panel-button,
+#panel Gjs_appindicatorsupport_rgcjonas_gmail_com_indicatorStatusIcon_AppIndicatorsIndicatorStatusIcon.panel-button {
+  -natural-hpadding: 17px !important;
+  -minimum-hpadding: 17px !important;
+}
+
+#panel .screencast-indicator,
+#panel .remote-access-indicator {
+  color: #FFD600;
+}
+
+#appMenu {
+  spacing: 6px;
+}
+
+#appMenu .label-shadow {
+  color: transparent;
+}
+
+#appMenu .panel-status-menu-box {
+  padding: 0 6px;
+  spacing: 6px;
+}
+
+/* Activities Ripple */
+.ripple-box {
+  background-color: rgba(26, 115, 232, 0.35);
+  width: 52px;
+  height: 52px;
+  border-radius: 0 0 52px 0;
+}
+
+.ripple-box:rtl {
+  border-radius: 0 0 0 52px;
+}
+
+/* OVERVIEW */
+.controls-manager, .secondary-monitor-workspaces {
+  spacing: 12px;
+}
+
+#overviewGroup {
+  background-color: #242424;
+}
+
+.overview-controls {
+  padding-bottom: 32px;
+}
+
+/* Window Picker */
+.window-picker {
+  spacing: 6px;
+}
+
+.window-caption {
+  color: white;
+  background-color: rgba(52, 52, 52, 0.9);
+  border-radius: 9999px;
+  padding: 6px 12px;
+  box-shadow: none;
+  border: none;
+}
+
+.window-close, .screenshot-ui-close-button {
+  background-color: #242424;
+  color: white;
+  border-radius: 9999px;
+  padding: 3px;
+  height: 30px;
+  width: 30px;
+  box-shadow: -1px 1px 5px 0px rgba(0, 0, 0, 0.5);
+  transition-duration: 300ms;
+}
+
+.window-close StIcon, .screenshot-ui-close-button StIcon {
+  icon-size: 24px;
+}
+
+.window-close:hover, .screenshot-ui-close-button:hover {
+  background-color: #4a4a4a;
+}
+
+.window-close:active, .screenshot-ui-close-button:active {
+  color: rgba(255, 255, 255, 0.8);
+  background-color: #171717;
+}
+
+.workspace-background {
+  border-radius: 30px;
+  background-color: #242424;
+  box-shadow: 0 4px 16px 4px rgba(0, 0, 0, 0.15);
+}
+
+.search-entry {
+  min-height: 24px;
+  padding: 6px 6px;
+  width: 320px;
+  border-radius: 9999px;
+  selection-background-color: #1A73E8;
+  selected-color: white !important;
+  caret-color: rgba(0, 0, 0, 0.6);
+  color: rgba(0, 0, 0, 0.6);
+  background-color: #FFFFFF;
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.search-entry:hover {
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.12) !important;
+}
+
+.search-entry:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #1A73E8 !important;
+}
+
+.search-entry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.search-entry .search-entry-icon {
+  icon-size: 16px;
+  padding: 0 4px;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.search-entry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+#overview .search-entry {
+  margin-top: 12px;
+  margin-bottom: 6px;
+  border: none !important;
+  caret-color: rgba(0, 0, 0, 0.75);
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.75);
+  border-color: transparent !important;
+  box-shadow: none !important;
+}
+
+#overview .search-entry:hover {
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.85);
+  box-shadow: none !important;
+}
+
+#overview .search-entry:focus {
+  color: rgba(0, 0, 0, 0.85);
+  border-color: transparent;
+  background-color: rgba(255, 255, 255, 0.95);
+  border: none !important;
+  box-shadow: none !important;
+  selection-background-color: #1A73E8;
+  selected-color: white !important;
+}
+
+#overview .search-entry .search-entry-icon {
+  color: rgba(0, 0, 0, 0.65);
+}
+
+#overview .search-entry:hover .search-entry-icon, #overview .search-entry:focus .search-entry-icon {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+#overview .search-entry StLabel.hint-text {
+  color: rgba(0, 0, 0, 0.35);
+}
+
+/* Search */
+#searchResults {
+  margin: 0 4px;
+}
+
+#searchResultsContent {
+  max-width: 1044px;
+}
+
+.search-section {
+  spacing: 12px;
+}
+
+.search-section .search-section-separator {
+  height: 8px;
+  background-color: transparent;
+}
+
+.search-section-content {
+  background-color: rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  color: white;
+  padding: 12px;
+  margin: 0 12px;
+}
+
+.list-search-result, .search-provider-icon {
+  border-radius: 10px;
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.list-search-result:focus, .search-provider-icon:focus, .list-search-result:hover, .search-provider-icon:hover, .list-search-result:selected, .search-provider-icon:selected {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  transition-duration: 200ms;
+  border-radius: 10px;
+}
+
+.list-search-result:active, .search-provider-icon:active, .list-search-result:checked, .search-provider-icon:checked {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-radius: 10px;
+}
+
+.search-statustext {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.grid-search-results {
+  spacing: 30px;
+  margin: 0 12px;
+}
+
+.search-provider-icon:ltr {
+  margin-right: 4px;
+}
+
+.search-provider-icon:rtl {
+  margin-left: 4px;
+}
+
+.search-provider-icon .list-search-provider-content {
+  spacing: 12px;
+}
+
+.search-provider-icon .list-search-provider-content .list-search-provider-details {
+  width: 120px;
+  margin-top: 0;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.list-search-results {
+  spacing: 6px;
+}
+
+.list-search-result .list-search-result-content {
+  spacing: 6px;
+}
+
+.list-search-result .list-search-result-title {
+  spacing: 12px;
+}
+
+.list-search-result .list-search-result-description {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Dash */
+#dash {
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+#dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 9999px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+#dash .dash-item-container .placeholder {
+  background-image: none;
+  background-size: contain;
+  height: 32px;
+}
+
+#dash .dash-item-container .empty-dash-drop-target {
+  width: 32px;
+  height: 32px;
+}
+
+#dash .dash-item-container .show-apps,
+#dash .dash-item-container .overview-tile,
+#dash .dash-item-container .grid-search-result {
+  background: none;
+  box-shadow: none;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  margin: 0 2px;
+  padding-bottom: 12px;
+}
+
+#dash .dash-item-container .show-apps .overview-icon,
+#dash .dash-item-container .overview-tile .overview-icon,
+#dash .dash-item-container .grid-search-result .overview-icon {
+  border-radius: 9999px;
+  padding: 6px;
+  spacing: 6px;
+  text-align: center;
+  transition-duration: 100ms;
+  background-color: transparent;
+  color: white;
+}
+
+#dash .dash-item-container .show-apps:focus .overview-icon,
+#dash .dash-item-container .overview-tile:focus .overview-icon,
+#dash .dash-item-container .grid-search-result:focus .overview-icon {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#dash .dash-item-container .show-apps:hover .overview-icon,
+#dash .dash-item-container .overview-tile:hover .overview-icon,
+#dash .dash-item-container .grid-search-result:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#dash .dash-item-container .show-apps:active .overview-icon,
+#dash .dash-item-container .overview-tile:active .overview-icon,
+#dash .dash-item-container .grid-search-result:active .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#dash .dash-item-container .show-apps:checked .overview-icon,
+#dash .dash-item-container .overview-tile:checked .overview-icon,
+#dash .dash-item-container .grid-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#dash .dash-item-container .app-grid-running-dot {
+  offset-y: -12px;
+}
+
+#dash .dash-separator {
+  width: 1px;
+  margin-left: 4px;
+  margin-right: 4px;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-separator,
+#dash .dash-background {
+  margin-bottom: 12px;
+}
+
+.dash-label {
+  border-radius: 9999px;
+  padding: 6px 12px;
+  margin: 9px;
+  color: white;
+  background-color: rgba(0, 0, 0, 0.75);
+  border: none;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.32);
+  text-align: center;
+  -y-offset: 0;
+  -x-offset: 0;
+}
+
+/* App Grid */
+.icon-grid {
+  row-spacing: 12px;
+  column-spacing: 12px;
+  max-row-spacing: 36px;
+  max-column-spacing: 36px;
+  page-padding-top: 24px;
+  page-padding-bottom: 24px;
+  page-padding-left: 18px;
+  page-padding-right: 18px;
+}
+
+/* App Icons */
+.overview-tile, .grid-search-result {
+  border-radius: 20px;
+  padding: 12px;
+  spacing: 6px;
+  transition-duration: 150ms;
+  text-align: center;
+  background-color: transparent;
+  color: white;
+  border: 1px solid transparent;
+  box-shadow: inset 0 1px transparent;
+}
+
+.overview-tile:hover, .grid-search-result:hover, .overview-tile:focus, .grid-search-result:focus, .overview-tile:highlighted, .grid-search-result:highlighted, .overview-tile:selected, .grid-search-result:selected {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+  transition-duration: 0ms;
+  border-image: none;
+  background-image: none;
+}
+
+.overview-tile:active, .grid-search-result:active, .overview-tile:checked, .grid-search-result:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+  transition-duration: 150ms;
+  color: white;
+}
+
+.overview-tile .overview-icon.overview-icon-with-label > StBoxLayout, .grid-search-result .overview-icon.overview-icon-with-label > StBoxLayout {
+  spacing: 6px;
+}
+
+.notification-badge {
+  min-width: 16px;
+  min-height: 16px;
+  color: white;
+  background-color: #1A73E8;
+  border-radius: 9999px;
+  padding: 0.2em 0.4em;
+  text-align: center;
+}
+
+.app-folder {
+  background-color: rgba(255, 255, 255, 0.04);
+  border-radius: 20px;
+}
+
+.app-folder:focus, .app-folder:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.app-folder:active, .app-folder:highlighted, .app-folder:selected, .app-folder:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder:insensitive {
+  background-color: transparent;
+}
+
+.app-grid-running-dot {
+  width: 6px;
+  height: 3px;
+  border-radius: 2px;
+  background-color: rgba(255, 255, 255, 0.3);
+  margin-bottom: 1px;
+}
+
+StWidget.focused .app-grid-running-dot {
+  width: 18px;
+  background-color: #1A73E8;
+}
+
+.app-folder-dialog-container {
+  padding-top: 38px;
+}
+
+.app-folder-dialog {
+  border-radius: 40px;
+  border: none;
+  background-color: rgba(36, 36, 36, 0.95);
+  color: white;
+  spacing: 6px;
+  box-shadow: none;
+  outline: none;
+}
+
+.app-folder-dialog .folder-name-container {
+  padding: 24px 36px 0;
+  spacing: 12px;
+  /* FIXME: this is to keep the label in sync with the entry */
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label,
+.app-folder-dialog .folder-name-container .folder-name-entry {
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry {
+  min-height: 28px;
+  padding: 6px;
+  border: none;
+  color: white;
+  background-color: rgba(255, 255, 255, 0.15);
+  caret-color: white;
+  selection-background-color: rgba(255, 255, 255, 0.12) !important;
+  selected-color: white !important;
+  width: 300px;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:hover .search-entry-icon, .app-folder-dialog .folder-name-container .folder-name-entry:focus .search-entry-icon {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:insensitive, .app-folder-dialog .folder-name-container .folder-name-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label {
+  padding: 5px 7px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.app-folder-dialog .folder-name-container .icon-button, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button, .app-folder-dialog .folder-name-container .background-app-item .close-button, .background-app-item .app-folder-dialog .folder-name-container .close-button {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.7);
+  border: none;
+  height: 32px;
+  width: 32px;
+  padding: 6px;
+  border-radius: 9999px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button > StIcon, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button > StIcon, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button > StIcon,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button > StIcon,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button > StIcon, .app-folder-dialog .folder-name-container .background-app-item .close-button > StIcon, .background-app-item .app-folder-dialog .folder-name-container .close-button > StIcon {
+  icon-size: 16px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button:hover, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:hover, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:hover,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:hover,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:hover, .app-folder-dialog .folder-name-container .background-app-item .close-button:hover, .background-app-item .app-folder-dialog .folder-name-container .close-button:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.app-folder-dialog .folder-name-container .icon-button:checked, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:checked, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:checked,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:checked,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:checked, .app-folder-dialog .folder-name-container .background-app-item .close-button:checked, .background-app-item .app-folder-dialog .folder-name-container .close-button:checked, .app-folder-dialog .folder-name-container .icon-button:active, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:active, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:active,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:active,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:active, .app-folder-dialog .folder-name-container .background-app-item .close-button:active, .background-app-item .app-folder-dialog .folder-name-container .close-button:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder-dialog .icon-grid {
+  row-spacing: 12px;
+  column-spacing: 30px;
+  page-padding-top: 0;
+  page-padding-bottom: 0;
+  page-padding-left: 0;
+  page-padding-right: 0;
+}
+
+.app-folder-dialog .page-indicators {
+  margin-bottom: 18px;
+}
+
+.rename-folder-popup .rename-folder-popup-item {
+  spacing: 6px;
+}
+
+.rename-folder-popup .rename-folder-popup-item:ltr, .rename-folder-popup .rename-folder-popup-item:rtl {
+  padding: 0 12px;
+}
+
+.app-menu,
+.app-well-menu {
+  max-width: 27.25em;
+}
+
+.page-indicator {
+  padding: 6px 12px 0;
+}
+
+.page-indicator .page-indicator-icon {
+  width: 10px;
+  height: 10px;
+  border-radius: 10px;
+  background-color: white;
+  transition-duration: 400ms;
+}
+
+.apps-scroll-view {
+  padding: 0;
+}
+
+.system-action-icon {
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  border-radius: 9999px;
+}
+
+.page-navigation-hint.dnd {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.page-navigation-hint.next:ltr, .page-navigation-hint.previous:rtl {
+  background-gradient-start: rgba(255, 255, 255, 0.05);
+  background-gradient-end: transparent;
+  background-gradient-direction: horizontal;
+  border-radius: 15px 0px 0px 15px;
+}
+
+.page-navigation-hint.previous:ltr, .page-navigation-hint.next:rtl {
+  background-gradient-start: transparent;
+  background-gradient-end: rgba(255, 255, 255, 0.05);
+  background-gradient-direction: horizontal;
+  border-radius: 0px 15px 15px 0px;
+}
+
+.page-navigation-arrow {
+  margin: 6px;
+  padding: 18px;
+  width: 24px;
+  height: 24px;
+  border-radius: 9999px;
+  color: white;
+  background-color: transparent;
+}
+
+.page-navigation-arrow:insensitive {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.page-navigation-arrow:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.page-navigation-arrow:active {
+  background-color: rgba(255, 255, 255, 0.24);
+  color: white;
+}
+
+/* Workspace pager */
+.workspace-thumbnails .workspace-thumbnail {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border: none;
+}
+
+.workspace-thumbnails {
+  visible-width: 32px;
+  spacing: 6px;
+  padding: 6px;
+}
+
+.workspace-thumbnails .workspace-thumbnail {
+  border-radius: 3px;
+}
+
+.workspace-thumbnails .placeholder {
+  background-image: url("resource:///org/gnome/shell/theme/dash-placeholder.svg");
+  background-size: contain;
+  width: 18px;
+}
+
+.workspace-thumbnail-indicator {
+  border: 3px solid #1A73E8;
+  border-radius: 3px;
+  padding: 0px;
+}
+
+.ripple-pointer-location {
+  width: 48px;
+  height: 48px;
+  border-radius: 24px;
+  background-color: rgba(165, 200, 246, 0.3);
+  box-shadow: 0 0 2px 2px #77acf1;
+}
+
+.pie-timer {
+  width: 60px;
+  height: 60px;
+  -pie-border-width: 3px;
+  -pie-border-color: #1A73E8;
+  -pie-background-color: rgba(211, 228, 251, 0.3);
+}
+
+.magnifier-zoom-region {
+  border: 2px solid #1A73E8;
+}
+
+.magnifier-zoom-region.full-screen {
+  border-width: 0;
+}
+
+.select-area-rubberband {
+  background-color: rgba(26, 115, 232, 0.3);
+  border: 1px solid #1A73E8;
+}
+
+.user-icon {
+  background-size: contain;
+  color: rgba(255, 255, 255, 0.7);
+  border-radius: 9999px;
+  icon-size: 64px;
+}
+
+.user-icon:hover {
+  color: white;
+}
+
+.user-icon StIcon {
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 99px;
+  padding: 12px;
+  width: 40px;
+  height: 40px;
+}
+
+.user-icon.user-avatar {
+  border: 2px rgba(255, 255, 255, 0.7);
+}
+
+.user-widget.vertical .user-icon {
+  icon-size: 128px;
+}
+
+.user-widget.vertical .user-icon StIcon {
+  padding: 20px;
+  padding-top: 18px;
+  padding-bottom: 22px;
+  width: 88px;
+  height: 88px;
+}
+
+.lightbox {
+  background-color: black;
+}
+
+.flashspot {
+  background-color: white;
+}
+
+.hidden {
+  color: rgba(0, 0, 0, 0);
+}
+
+.caps-lock-warning-label {
+  text-align: center;
+  padding-bottom: 8px;
+  font-size: 10.5pt;
+  font-weight: 400;
+  color: #FFD600;
+}
+
+/* Workspace animation */
+.workspace-animation {
+  background-color: #242424;
+}
+
+/* Tiled window previews */
+.tile-preview {
+  background-color: rgba(26, 115, 232, 0.3);
+  border: 1px solid #1A73E8;
+}
+
+.tile-preview-left.on-primary {
+  border-radius: 11px 0 0 0;
+}
+
+.tile-preview-right.on-primary {
+  border-radius: 0 11px 0 0;
+}
+
+.tile-preview-left.tile-preview-right.on-primary {
+  border-radius: 11px 11px 0 0;
+}
+
+/* On-screen Keyboard */
+#keyboard {
+  background-color: rgba(0, 0, 0, 0.85);
+  border: none;
+  border-top-width: 0;
+  box-shadow: none;
+}
+
+#keyboard .page-indicator {
+  padding: 6px;
+}
+
+#keyboard .page-indicator .page-indicator-icon {
+  width: 8px;
+  height: 8px;
+}
+
+.key-container {
+  padding: 4px;
+  spacing: 4px;
+}
+
+.keyboard-key {
+  min-height: 2em;
+  min-width: 2em;
+  font-size: 14pt;
+  font-weight: bold;
+  border-radius: 10px;
+  border: none;
+  color: inherit;
+  background-color: #FAFAFA;
+  box-shadow: 0 1px rgba(0, 0, 0, 0.2);
+}
+
+.keyboard-key:focus, .keyboard-key:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #e1e1e1;
+}
+
+.keyboard-key:checked, .keyboard-key:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #c7c7c7;
+}
+
+.keyboard-key:grayed {
+  background-color: #242424;
+  color: white;
+  border-color: #242424;
+}
+
+.keyboard-key.default-key {
+  background-color: #BFBFBF;
+  box-shadow: 0 1px rgba(0, 0, 0, 0.2);
+}
+
+.keyboard-key.default-key:focus, .keyboard-key.default-key:hover {
+  color: rgba(0, 0, 0, 0.6);
+  background-color: #FAFAFA;
+}
+
+.keyboard-key.default-key:checked, .keyboard-key.default-key:active {
+  color: rgba(0, 0, 0, 0.6);
+  background-color: #ebebeb;
+}
+
+.keyboard-key.enter-key {
+  background-color: #1A73E8;
+  color: white;
+}
+
+.keyboard-key.enter-key:focus, .keyboard-key.enter-key:hover {
+  color: white;
+  background-color: #3181ea;
+}
+
+.keyboard-key.enter-key:checked, .keyboard-key.enter-key:active {
+  color: white;
+  background-color: #135cbc;
+}
+
+.keyboard-key.shift-key-uppercase {
+  color: #1A73E8;
+}
+
+.keyboard-key StIcon {
+  icon-size: 1.125em;
+}
+
+.keyboard-subkeys {
+  color: inherit;
+  -arrow-border-radius: 10px;
+  -arrow-background-color: rgba(0, 0, 0, 0.45);
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
+  -boxpointer-gap: 5px;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.32);
+}
+
+.emoji-page .keyboard-key {
+  background-color: transparent;
+  border: none;
+  color: initial;
+}
+
+.emoji-panel .keyboard-key:latched {
+  border-color: #3181ea;
+  background-color: #1A73E8;
+}
+
+.word-suggestions {
+  font-size: 14pt;
+  spacing: 12px;
+  min-height: 20pt;
+}
+
+/* Looking Glass */
+#LookingGlassDialog {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: #242424;
+  spacing: 6px;
+  padding: 0;
+  border: none;
+  border-radius: 20px;
+  box-shadow: 0 10px 15px rgba(0, 0, 0, 0.45);
+}
+
+#LookingGlassDialog > #Toolbar {
+  padding: 6px 9px;
+  border: none;
+  border-radius: 20px 20px 0 0;
+  background-color: #3e3e3e;
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+#LookingGlassDialog .labels {
+  spacing: 0;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+#LookingGlassDialog .notebook-tab {
+  -natural-hpadding: 6px;
+  -minimum-hpadding: 6px;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.5);
+  transition-duration: 150ms;
+  padding-left: 18px;
+  padding-right: 18px;
+  min-height: 24px;
+  border-radius: 10px;
+  background-color: transparent;
+}
+
+#LookingGlassDialog .notebook-tab:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.15);
+  text-shadow: none;
+  box-shadow: none;
+}
+
+#LookingGlassDialog .notebook-tab:selected {
+  background-color: rgba(255, 255, 255, 0.1);
+  box-shadow: none;
+  color: white;
+  text-shadow: none;
+}
+
+#LookingGlassDialog StBoxLayout#EvalBox {
+  padding: 6px;
+  spacing: 6px;
+}
+
+#LookingGlassDialog StBoxLayout#ResultsArea {
+  spacing: 6px;
+}
+
+.lg-dialog StEntry {
+  selection-background-color: #1A73E8;
+  selected-color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.lg-dialog .shell-link {
+  color: #1A73E8;
+}
+
+.lg-dialog .shell-link:hover {
+  color: #1A73E8;
+}
+
+.lg-dialog .actor-link {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.lg-dialog .actor-link:hover {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.lg-dialog .actor-link:active {
+  color: rgba(204, 204, 204, 0.5);
+}
+
+.lg-dialog .actor-link StIcon {
+  icon-size: 12px;
+}
+
+.lg-completions-text {
+  font-size: 1em;
+  font-style: italic;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lg-obj-inspector-title {
+  spacing: 6px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lg-obj-inspector-button {
+  min-height: 36px;
+  padding: 6px;
+  border: none;
+  border-radius: 10px;
+  font-size: 10.5pt;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.6);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.lg-obj-inspector-button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.lg-obj-inspector-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.lg-obj-inspector-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.lg-obj-inspector-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.lg-obj-inspector-button:hover {
+  border: none;
+}
+
+#lookingGlassExtensions {
+  padding: 6px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lg-extensions-list {
+  padding: 6px;
+  spacing: 6px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lg-extension {
+  border: none;
+  border-radius: 10px;
+  background-color: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.7);
+  padding: 6px;
+  box-shadow: none;
+}
+
+.lg-extension-name {
+  font-size: 18pt;
+  font-weight: 400;
+  color: white;
+}
+
+.lg-extension-meta {
+  spacing: 6px;
+}
+
+#LookingGlassPropertyInspector {
+  color: white;
+  background: #333333;
+  border: none;
+  border-radius: 10px;
+  padding: 6px;
+  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.32);
+}
+
+#LookingGlassPropertyInspector .window-close, #LookingGlassPropertyInspector .screenshot-ui-close-button {
+  margin: 6px;
+}
+
+.lg-debug-flag-button {
+  color: white;
+}
+
+.lg-debug-flag-button StLabel {
+  padding: 6px, 12px;
+}
+
+.lg-debug-flag-button:hover {
+  color: white;
+}
+
+.lg-debug-flag-button:active {
+  color: #cccccc;
+}
+
+.lg-debug-flags-header {
+  padding-top: 12px;
+  padding: 6px;
+}
+
+.icon-label-button-container {
+  spacing: 6px;
+  font-size: 9pt;
+  font-weight: 400;
+}
+
+.icon-label-button-container StIcon {
+  icon-size: 32px;
+}
+
+.screenshot-ui-panel {
+  color: white;
+  background-color: #212121;
+  border: none;
+  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.32);
+  border-radius: 31px;
+  padding: 18px;
+  padding-bottom: 12px;
+  margin-bottom: 4em;
+  spacing: 12px;
+}
+
+.screenshot-ui-close-button {
+  padding: 6px !important;
+}
+
+.screenshot-ui-close-button.left {
+  margin-left: 8px;
+}
+
+.screenshot-ui-close-button.right {
+  margin-right: 8px;
+}
+
+.screenshot-ui-type-button {
+  min-width: 48px;
+  padding: 12px 18px !important;
+  border-radius: 13px;
+}
+
+.screenshot-ui-capture-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 9999px;
+  border: 4px white;
+  padding: 4px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle {
+  background-color: white;
+  transition-duration: 200ms;
+  border-radius: 9999px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle:hover, .screenshot-ui-capture-button .screenshot-ui-capture-button-circle:focus {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.screenshot-ui-capture-button:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:focus .screenshot-ui-capture-button-circle {
+  background-color: #d9d9d9;
+}
+
+.screenshot-ui-capture-button:active .screenshot-ui-capture-button-circle {
+  background-color: gray;
+}
+
+.screenshot-ui-capture-button:cast .screenshot-ui-capture-button-circle {
+  background-color: #E53935;
+}
+
+.screenshot-ui-capture-button:cast:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:cast:focus .screenshot-ui-capture-button-circle {
+  background-color: #e84f4c;
+}
+
+.screenshot-ui-capture-button:cast:active .screenshot-ui-capture-button-circle {
+  background-color: #da201c;
+}
+
+.screenshot-ui-shot-cast-container {
+  background-color: rgba(0, 0, 0, 0.08);
+  border-radius: 10px;
+  padding: 3px;
+  spacing: 3px;
+}
+
+.screenshot-ui-shot-cast-container:ltr {
+  margin-left: 3px;
+}
+
+.screenshot-ui-shot-cast-container:rtl {
+  margin-right: 3px;
+}
+
+.screenshot-ui-shot-cast-button {
+  padding: 6px 12px;
+  background-color: transparent;
+  border-radius: 7px;
+}
+
+.screenshot-ui-shot-cast-button:hover, .screenshot-ui-shot-cast-button:focus {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.screenshot-ui-shot-cast-button:active {
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.screenshot-ui-shot-cast-button:checked {
+  background-color: white;
+  color: black;
+}
+
+.screenshot-ui-shot-cast-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-show-pointer-button {
+  border-radius: 9999px;
+  padding: 12px !important;
+}
+
+.screenshot-ui-show-pointer-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-selection {
+  border: 2px white;
+}
+
+.screenshot-ui-area-selector-handle {
+  border-radius: 9999px;
+  background-color: white;
+  box-shadow: 0 1px 3px 2px rgba(0, 0, 0, 0.2);
+  width: 24px;
+  height: 24px;
+}
+
+.screenshot-ui-window-selector {
+  background-color: #242424;
+}
+
+.screenshot-ui-window-selector .screenshot-ui-window-selector-window-container {
+  margin: 100px;
+}
+
+.screenshot-ui-window-selector:primary-monitor .screenshot-ui-window-selector-window-container {
+  margin-bottom: 200px;
+}
+
+.screenshot-ui-window-selector-window-border {
+  transition-duration: 200ms;
+  border-radius: 10px;
+  border: 6px transparent;
+}
+
+.screenshot-ui-window-selector-check {
+  transition-duration: 200ms;
+  color: transparent;
+  border-radius: 9999px;
+  border-width: 12px;
+  icon-size: 24px;
+}
+
+.screenshot-ui-window-selector-window:hover .screenshot-ui-window-selector-window-border {
+  border-color: #1151a5;
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-window-border {
+  border-color: #1A73E8;
+  background-color: rgba(26, 115, 232, 0.2);
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-check {
+  color: white;
+  background-color: #1A73E8;
+}
+
+.screenshot-ui-screen-selector {
+  transition-duration: 200ms;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-screen-selector:hover {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-screen-selector:active {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.screenshot-ui-screen-selector:checked {
+  background-color: transparent;
+  border: 2px white;
+}
+
+.screenshot-ui-tooltip {
+  color: white;
+  background-color: #242424;
+  border-radius: 9999px;
+  padding: 6px 12px;
+  text-align: center;
+  -y-offset: 24px;
+}
+
+/* Login Dialog */
+.login-dialog-banner-view {
+  padding-top: 24px;
+  max-width: 23em;
+}
+
+.login-dialog,
+.unlock-dialog {
+  border: none;
+  background-color: transparent;
+}
+
+.login-dialog StEntry,
+.unlock-dialog StEntry {
+  selection-background-color: #1A73E8;
+  selected-color: white !important;
+  caret-color: rgba(0, 0, 0, 0.6);
+  color: rgba(0, 0, 0, 0.6);
+  background-color: #FFFFFF;
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.login-dialog StEntry:focus,
+.unlock-dialog StEntry:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #1A73E8 !important;
+}
+
+.login-dialog StEntry:insensitive,
+.unlock-dialog StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .modal-dialog-button-box,
+.unlock-dialog .modal-dialog-button-box {
+  spacing: 3px;
+}
+
+.login-dialog .modal-dialog-button,
+.unlock-dialog .modal-dialog-button {
+  padding: 4px 18px;
+  box-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:hover, .login-dialog .modal-dialog-button:focus,
+.unlock-dialog .modal-dialog-button:hover,
+.unlock-dialog .modal-dialog-button:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:active,
+.unlock-dialog .modal-dialog-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:insensitive,
+.unlock-dialog .modal-dialog-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default,
+.unlock-dialog .modal-dialog-button:default {
+  color: white;
+  background-color: #1A73E8;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:hover, .login-dialog .modal-dialog-button:default:focus,
+.unlock-dialog .modal-dialog-button:default:hover,
+.unlock-dialog .modal-dialog-button:default:focus {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:active,
+.unlock-dialog .modal-dialog-button:default:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.24);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:insensitive,
+.unlock-dialog .modal-dialog-button:default:insensitive {
+  color: rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.login-dialog .cancel-button,
+.login-dialog .switch-user-button,
+.login-dialog .login-dialog-session-list-button,
+.unlock-dialog .cancel-button,
+.unlock-dialog .switch-user-button,
+.unlock-dialog .login-dialog-session-list-button {
+  padding: 0;
+  border-radius: 99px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background-color: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .cancel-button:hover, .login-dialog .cancel-button:focus,
+.login-dialog .switch-user-button:hover,
+.login-dialog .switch-user-button:focus,
+.login-dialog .login-dialog-session-list-button:hover,
+.login-dialog .login-dialog-session-list-button:focus,
+.unlock-dialog .cancel-button:hover,
+.unlock-dialog .cancel-button:focus,
+.unlock-dialog .switch-user-button:hover,
+.unlock-dialog .switch-user-button:focus,
+.unlock-dialog .login-dialog-session-list-button:hover,
+.unlock-dialog .login-dialog-session-list-button:focus {
+  color: white;
+}
+
+.login-dialog .cancel-button:active,
+.login-dialog .switch-user-button:active,
+.login-dialog .login-dialog-session-list-button:active,
+.unlock-dialog .cancel-button:active,
+.unlock-dialog .switch-user-button:active,
+.unlock-dialog .login-dialog-session-list-button:active {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.login-dialog .cancel-button StIcon,
+.login-dialog .switch-user-button StIcon,
+.login-dialog .login-dialog-session-list-button StIcon,
+.unlock-dialog .cancel-button StIcon,
+.unlock-dialog .switch-user-button StIcon,
+.unlock-dialog .login-dialog-session-list-button StIcon {
+  icon-size: 16px;
+}
+
+.login-dialog .caps-lock-warning-label,
+.login-dialog .login-dialog-message-warning,
+.unlock-dialog .caps-lock-warning-label,
+.unlock-dialog .login-dialog-message-warning {
+  color: white;
+}
+
+.login-dialog-logo-bin {
+  padding: 24px 0px;
+}
+
+.login-dialog-banner {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-button-box {
+  width: 23em;
+  spacing: 5px;
+}
+
+.login-dialog-message {
+  text-align: center;
+}
+
+.login-dialog-user-selection-box {
+  padding: 100px 0px;
+}
+
+.login-dialog-not-listed-label {
+  padding-left: 2px;
+  font-size: 1em;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.7);
+  padding-top: 1em;
+}
+
+.login-dialog-not-listed-label:hover {
+  color: white;
+}
+
+.login-dialog-not-listed-label:focus {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.login-dialog-not-listed-button:focus .login-dialog-not-listed-label, .login-dialog-not-listed-button:hover .login-dialog-not-listed-label {
+  color: white;
+}
+
+.login-dialog-user-list-view {
+  -st-vfade-offset: 1em;
+}
+
+.login-dialog-user-list {
+  spacing: 12px;
+  width: 23em;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:selected {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: white;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:logged-in {
+  border-right: 2px solid white;
+}
+
+.login-dialog-user-list-item {
+  border-radius: 10px;
+  padding: 6px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-user-list-item:ltr {
+  padding-right: 1em;
+}
+
+.login-dialog-user-list-item:rtl {
+  padding-left: 1em;
+}
+
+.login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: white;
+}
+
+.login-dialog-user-list-item .login-dialog-timed-login-indicator {
+  height: 2px;
+  margin: 6px 0 0 0;
+  background-color: white;
+}
+
+.login-dialog-user-list-item:focus .login-dialog-timed-login-indicator {
+  background-color: white;
+}
+
+.user-widget-label {
+  color: white;
+}
+
+.user-widget.horizontal .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+  padding-left: 15px;
+}
+
+.user-widget.horizontal .user-widget-label:ltr {
+  padding-left: 14px;
+  text-align: left;
+}
+
+.user-widget.horizontal .user-widget-label:rtl {
+  padding-right: 14px;
+  text-align: right;
+}
+
+.user-widget.vertical .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  text-align: center;
+  font-weight: normal;
+  padding-top: 16px;
+}
+
+.login-dialog-prompt-layout {
+  padding-top: 24px;
+  padding-bottom: 12px;
+  spacing: 12px;
+  width: 23em;
+}
+
+.login-dialog-prompt-entry {
+  height: 1.5em;
+}
+
+.login-dialog-prompt-label {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 1em;
+  padding-top: 1em;
+}
+
+/* Screen Shield */
+.unlock-dialog-clock {
+  color: white;
+  font-weight: 300;
+  text-align: center;
+  spacing: 24px;
+  padding-bottom: 2.5em;
+}
+
+.unlock-dialog-clock-time {
+  font-size: 64pt;
+  padding-top: 42px;
+  font-feature-settings: "tnum";
+}
+
+.unlock-dialog-clock-date {
+  font-size: 16pt;
+  font-weight: normal;
+}
+
+.unlock-dialog-clock-hint {
+  font-weight: normal;
+  padding-top: 48px;
+}
+
+.unlock-dialog-notifications-container {
+  margin: 12px 0;
+  spacing: 6px;
+  width: 23em;
+  background-color: transparent;
+}
+
+.unlock-dialog-notifications-container .summary-notification-stack-scrollview {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.unlock-dialog-notifications-container .notification,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source {
+  padding: 12px 6px;
+  border: none;
+  background-color: rgba(52, 52, 52, 0.9);
+  color: white;
+  border-radius: 10px;
+}
+
+.unlock-dialog-notifications-container .notification.critical,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source.critical {
+  background-color: rgba(36, 36, 36, 0.9);
+}
+
+.unlock-dialog-notification-label {
+  padding: 0px 0px 0px 12px;
+}
+
+.unlock-dialog-notification-count-text {
+  weight: bold;
+  padding: 0 6px;
+  color: rgba(52, 52, 52, 0.9);
+  background-color: rgba(255, 255, 255, 0.7);
+  border-radius: 99px;
+  margin-right: 12px;
+}
+
+.screen-shield-background {
+  background: black;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.6);
+}
+
+#lockDialogGroup {
+  background-color: #242424;
+}
+
+#unlockDialogNotifications StButton#vhandle, #unlockDialogNotifications StButton#hhandle {
+  background-color: rgba(52, 52, 52, 0.2);
+}
+
+#unlockDialogNotifications StButton#vhandle:hover, #unlockDialogNotifications StButton#vhandle:focus, #unlockDialogNotifications StButton#hhandle:hover, #unlockDialogNotifications StButton#hhandle:focus {
+  background-color: rgba(52, 52, 52, 0.4);
+}
+
+#unlockDialogNotifications StButton#vhandle:active, #unlockDialogNotifications StButton#hhandle:active {
+  background-color: rgba(26, 115, 232, 0.5);
+}
+
+.bottom #dashtodockDashScrollview,
+.top #dashtodockDashScrollview {
+  -st-hfade-offset: 24px;
+}
+
+.left #dashtodockDashScrollview,
+.right #dashtodockDashScrollview {
+  -st-vfade-offset: 24px;
+}
+
+#dashtodockContainer {
+  background: transparent;
+}
+
+#dashtodockContainer .number-overlay {
+  min-width: 1.2em;
+  min-height: 1.2em;
+  color: white;
+  background-color: rgba(0, 0, 0, 0.75);
+  text-align: center;
+  padding: 0.2em 0.4em;
+}
+
+#dashtodockContainer .notification-badge {
+  min-width: 16px;
+  min-height: 16px;
+  color: white;
+  background-color: #1A73E8;
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.25);
+  border-radius: 9999px;
+  margin: 2px 3px 5px;
+  padding: 0.2em 0.4em;
+  font-weight: bold;
+  text-align: center;
+}
+
+#dashtodockContainer.top #dash .dash-background {
+  border-radius: 9999px !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash, #dashtodockContainer.top.shrink.straight-corner #dash, #dashtodockContainer.top.extended #dash, #dashtodockContainer.top.shrink.extended #dash {
+  margin: 0 !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .dash-background, #dashtodockContainer.top.shrink.straight-corner #dash .dash-background, #dashtodockContainer.top.extended #dash .dash-background, #dashtodockContainer.top.shrink.extended #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .show-apps,
+#dashtodockContainer.top.straight-corner #dash .overview-tile,
+#dashtodockContainer.top.straight-corner #dash .grid-search-result, #dashtodockContainer.top.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.top.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.top.extended #dash .show-apps,
+#dashtodockContainer.top.extended #dash .overview-tile,
+#dashtodockContainer.top.extended #dash .grid-search-result, #dashtodockContainer.top.shrink.extended #dash .show-apps,
+#dashtodockContainer.top.shrink.extended #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.bottom #dash .dash-background {
+  border-radius: 9999px !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash, #dashtodockContainer.bottom.shrink.straight-corner #dash, #dashtodockContainer.bottom.extended #dash, #dashtodockContainer.bottom.shrink.extended #dash {
+  margin: 0 !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .dash-background, #dashtodockContainer.bottom.shrink.straight-corner #dash .dash-background, #dashtodockContainer.bottom.extended #dash .dash-background, #dashtodockContainer.bottom.shrink.extended #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.straight-corner #dash .overview-tile,
+#dashtodockContainer.bottom.straight-corner #dash .grid-search-result, #dashtodockContainer.bottom.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.bottom.extended #dash .show-apps,
+#dashtodockContainer.bottom.extended #dash .overview-tile,
+#dashtodockContainer.bottom.extended #dash .grid-search-result, #dashtodockContainer.bottom.shrink.extended #dash .show-apps,
+#dashtodockContainer.bottom.shrink.extended #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.left #dash .dash-background {
+  border-radius: 9999px !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash, #dashtodockContainer.left.shrink.straight-corner #dash, #dashtodockContainer.left.extended #dash, #dashtodockContainer.left.shrink.extended #dash {
+  margin: 0 !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .dash-background, #dashtodockContainer.left.shrink.straight-corner #dash .dash-background, #dashtodockContainer.left.extended #dash .dash-background, #dashtodockContainer.left.shrink.extended #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .show-apps,
+#dashtodockContainer.left.straight-corner #dash .overview-tile,
+#dashtodockContainer.left.straight-corner #dash .grid-search-result, #dashtodockContainer.left.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.left.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.left.extended #dash .show-apps,
+#dashtodockContainer.left.extended #dash .overview-tile,
+#dashtodockContainer.left.extended #dash .grid-search-result, #dashtodockContainer.left.shrink.extended #dash .show-apps,
+#dashtodockContainer.left.shrink.extended #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.right #dash .dash-background {
+  border-radius: 9999px !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash, #dashtodockContainer.right.shrink.straight-corner #dash, #dashtodockContainer.right.extended #dash, #dashtodockContainer.right.shrink.extended #dash {
+  margin: 0 !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .dash-background, #dashtodockContainer.right.shrink.straight-corner #dash .dash-background, #dashtodockContainer.right.extended #dash .dash-background, #dashtodockContainer.right.shrink.extended #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .show-apps,
+#dashtodockContainer.right.straight-corner #dash .overview-tile,
+#dashtodockContainer.right.straight-corner #dash .grid-search-result, #dashtodockContainer.right.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.right.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.right.extended #dash .show-apps,
+#dashtodockContainer.right.extended #dash .overview-tile,
+#dashtodockContainer.right.extended #dash .grid-search-result, #dashtodockContainer.right.shrink.extended #dash .show-apps,
+#dashtodockContainer.right.shrink.extended #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.extended .dash-background, #dashtodockContainer.straight-corner .dash-background {
+  border-radius: 0 !important;
+}
+
+#dashtodockContainer.shrink .dash-background {
+  padding: 2px !important;
+}
+
+#dashtodockContainer.shrink .show-apps,
+#dashtodockContainer.shrink .overview-tile,
+#dashtodockContainer.shrink .grid-search-result {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.shrink.extended .dash-background {
+  border-radius: 0;
+}
+
+#dashtodockContainer #dash, #dashtodockContainer:overview #dash {
+  background: transparent;
+}
+
+#dashtodockContainer.left #dash, #dashtodockContainer.right #dash {
+  margin-top: 0 !important;
+  padding: 12px !important;
+}
+
+#dashtodockContainer.left #dash #dashtodockDashContainer, #dashtodockContainer.right #dash #dashtodockDashContainer {
+  padding: 10px 0 !important;
+}
+
+#dashtodockContainer.left .show-apps,
+#dashtodockContainer.left .overview-tile,
+#dashtodockContainer.left .grid-search-result, #dashtodockContainer.right .show-apps,
+#dashtodockContainer.right .overview-tile,
+#dashtodockContainer.right .grid-search-result {
+  padding: 2px 6px !important;
+}
+
+#dashtodockContainer.left .dash-background, #dashtodockContainer.right .dash-background {
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.left.shrink #dash #dashtodockDashContainer, #dashtodockContainer.right.shrink #dash #dashtodockDashContainer {
+  padding: 4px 0 !important;
+}
+
+#dashtodockContainer.left.shrink .dash-background, #dashtodockContainer.right.shrink .dash-background {
+  padding: 4px !important;
+}
+
+#dashtodockContainer.left.shrink .show-apps,
+#dashtodockContainer.left.shrink .overview-tile,
+#dashtodockContainer.left.shrink .grid-search-result, #dashtodockContainer.right.shrink .show-apps,
+#dashtodockContainer.right.shrink .overview-tile,
+#dashtodockContainer.right.shrink .grid-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer, #dashtodockContainer.right.extended #dash #dashtodockDashContainer, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.right.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child {
+  padding-top: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.right.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child {
+  padding-bottom: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.right.extended #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer > :first-child .show-apps {
+  padding-bottom: 6px !important;
+}
+
+#dashtodockContainer.left.extended #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.left.straight-corner #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.right.extended #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.right.straight-corner #dash #dashtodockDashContainer > :last-child .show-apps {
+  padding-bottom: 24px !important;
+}
+
+#dashtodockContainer.left.extended.shrink .dash-background, #dashtodockContainer.left.straight-corner.shrink .dash-background, #dashtodockContainer.right.extended.shrink .dash-background, #dashtodockContainer.right.straight-corner.shrink .dash-background {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended.shrink .show-apps,
+#dashtodockContainer.left.extended.shrink .overview-tile,
+#dashtodockContainer.left.extended.shrink .grid-search-result, #dashtodockContainer.left.straight-corner.shrink .show-apps,
+#dashtodockContainer.left.straight-corner.shrink .overview-tile,
+#dashtodockContainer.left.straight-corner.shrink .grid-search-result, #dashtodockContainer.right.extended.shrink .show-apps,
+#dashtodockContainer.right.extended.shrink .overview-tile,
+#dashtodockContainer.right.extended.shrink .grid-search-result, #dashtodockContainer.right.straight-corner.shrink .show-apps,
+#dashtodockContainer.right.straight-corner.shrink .overview-tile,
+#dashtodockContainer.right.straight-corner.shrink .grid-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended .overview-tile, #dashtodockContainer.left.extended .grid-search-result, #dashtodockContainer.left.straight-corner .overview-tile, #dashtodockContainer.left.straight-corner .grid-search-result, #dashtodockContainer.right.extended .overview-tile, #dashtodockContainer.right.extended .grid-search-result, #dashtodockContainer.right.straight-corner .overview-tile, #dashtodockContainer.right.straight-corner .grid-search-result {
+  padding: 2px 12px !important;
+}
+
+#dashtodockContainer.left.extended .show-apps, #dashtodockContainer.left.straight-corner .show-apps, #dashtodockContainer.right.extended .show-apps, #dashtodockContainer.right.straight-corner .show-apps {
+  padding: 2px 12px 24px !important;
+}
+
+#dashtodockContainer.top .dash-background, #dashtodockContainer.bottom .dash-background {
+  padding: 12px 10px !important;
+}
+
+#dashtodockContainer.top .show-apps,
+#dashtodockContainer.top .overview-tile,
+#dashtodockContainer.top .grid-search-result, #dashtodockContainer.bottom .show-apps,
+#dashtodockContainer.bottom .overview-tile,
+#dashtodockContainer.bottom .grid-search-result {
+  margin: 0 2px !important;
+  padding-bottom: 12px !important;
+}
+
+#dashtodockContainer.top .show-apps .overview-icon,
+#dashtodockContainer.top .overview-tile .overview-icon,
+#dashtodockContainer.top .grid-search-result .overview-icon, #dashtodockContainer.bottom .show-apps .overview-icon,
+#dashtodockContainer.bottom .overview-tile .overview-icon,
+#dashtodockContainer.bottom .grid-search-result .overview-icon {
+  padding: 6px !important;
+  spacing: 6px !important;
+}
+
+#dashtodockContainer.top.shrink .dash-background, #dashtodockContainer.bottom.shrink .dash-background {
+  padding: 4px 2px !important;
+}
+
+#dashtodockContainer.top.shrink .show-apps,
+#dashtodockContainer.top.shrink .overview-tile,
+#dashtodockContainer.top.shrink .grid-search-result, #dashtodockContainer.bottom.shrink .show-apps,
+#dashtodockContainer.bottom.shrink .overview-tile,
+#dashtodockContainer.bottom.shrink .grid-search-result {
+  margin: 0 !important;
+  padding: 0 2px 12px !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:first-child {
+  padding-left: 0 !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer #dashtodockDashScrollview:last-child {
+  padding-right: 0 !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer > :first-child .show-apps, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer > :first-child .show-apps {
+  padding-left: 0 !important;
+}
+
+#dashtodockContainer.top.extended #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.top.straight-corner #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.bottom.extended #dash #dashtodockDashContainer > :last-child .show-apps, #dashtodockContainer.bottom.straight-corner #dash #dashtodockDashContainer > :last-child .show-apps {
+  padding-right: 18px !important;
+}
+
+#dashtodockContainer.top.extended.shrink .dash-background, #dashtodockContainer.top.straight-corner.shrink .dash-background, #dashtodockContainer.bottom.extended.shrink .dash-background, #dashtodockContainer.bottom.straight-corner.shrink .dash-background {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.extended.shrink .show-apps,
+#dashtodockContainer.top.extended.shrink .overview-tile,
+#dashtodockContainer.top.extended.shrink .grid-search-result, #dashtodockContainer.top.straight-corner.shrink .show-apps,
+#dashtodockContainer.top.straight-corner.shrink .overview-tile,
+#dashtodockContainer.top.straight-corner.shrink .grid-search-result, #dashtodockContainer.bottom.extended.shrink .show-apps,
+#dashtodockContainer.bottom.extended.shrink .overview-tile,
+#dashtodockContainer.bottom.extended.shrink .grid-search-result, #dashtodockContainer.bottom.straight-corner.shrink .show-apps,
+#dashtodockContainer.bottom.straight-corner.shrink .overview-tile,
+#dashtodockContainer.bottom.straight-corner.shrink .grid-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.extended .dash-separator, #dashtodockContainer.top.straight-corner .dash-separator, #dashtodockContainer.bottom.extended .dash-separator, #dashtodockContainer.bottom.straight-corner .dash-separator {
+  margin: 0 8px !important;
+}
+
+#dashtodockContainer.top.extended .show-apps,
+#dashtodockContainer.top.extended .overview-tile,
+#dashtodockContainer.top.extended .grid-search-result, #dashtodockContainer.top.straight-corner .show-apps,
+#dashtodockContainer.top.straight-corner .overview-tile,
+#dashtodockContainer.top.straight-corner .grid-search-result, #dashtodockContainer.bottom.extended .show-apps,
+#dashtodockContainer.bottom.extended .overview-tile,
+#dashtodockContainer.bottom.extended .grid-search-result, #dashtodockContainer.bottom.straight-corner .show-apps,
+#dashtodockContainer.bottom.straight-corner .overview-tile,
+#dashtodockContainer.bottom.straight-corner .grid-search-result {
+  padding: 12px 2px !important;
+}
+
+#dashtodockContainer #dash .dash-background {
+  background-color: rgba(33, 33, 33, 0.65);
+}
+
+#dashtodockContainer #dash .app-grid-running-dot {
+  margin-bottom: 3px !important;
+  margin-top: 0 !important;
+  offset-y: 0 !important;
+}
+
+#dashtodockContainer #dash StWidget.focused .app-grid-running-dot {
+  background-color: #1A73E8;
+}
+
+#dashtodockContainer.opaque #dash .dash-background {
+  background-color: #212121;
+}
+
+#dashtodockContainer.transparent #dash .dash-background {
+  background-color: rgba(33, 33, 33, 0.65);
+}
+
+#dashtodockContainer:overview #dash {
+  background: none;
+}
+
+#dashtodockContainer:overview #dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+#dashtodockContainer:overview #dash StWidget.focused .app-grid-running-dot {
+  background-color: #1A73E8;
+}
+
+#dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
+  background-color: transparent !important;
+  box-shadow: none !important;
+}
+
+#dashtodockContainer.opaque:overview .dash-background, #dashtodockContainer.transparent:overview .dash-background {
+  background-color: transparent !important;
+}
+
+#dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
+  background: none;
+}
+
+#dashtodockContainer.running-dots .dash-item-container > StButton, #dashtodockContainer.dashtodock .dash-item-container > StButton {
+  transition-duration: 250ms;
+  background-size: contain;
+}
+
+#dashtodockContainer.shrink .dash-item-container > StButton, #dashtodockContainer.dashtodock .dash-item-container > StButton {
+  padding: 1px 2px;
+}
+
+#dashtodockContainer.extended .overview-tile .overview-icon, #dashtodockContainer.extended .grid-search-result .overview-icon,
+#dashtodockContainer.extended .show-apps .overview-icon, #dashtodockContainer.extended:overview .overview-tile .overview-icon,
+#dashtodockContainer.extended:overview .show-apps .overview-icon {
+  border-radius: 10px;
+}
+
+#dashtodockContainer .metro .overview-icon {
+  border-radius: 0;
+}
+
+.dashtodock-app-well-preview-menu-item {
+  padding: 1em 1em 0.5em 1em;
+}
+
+#dashtodockPreviewSeparator.popup-separator-menu-item-horizontal {
+  width: 1px;
+  height: auto;
+  border-right-width: 1px;
+  margin: 32px 0;
+}
+
+.dash-label.bottom {
+  margin-bottom: 18px !important;
+}
+
+.dashtopanelMainPanel {
+  border-radius: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+.dashtopanelMainPanel .dash-background {
+  background-color: rgba(33, 33, 33, 0.65);
+  margin-bottom: 0 !important;
+  padding: 0 !important;
+  border-radius: 0 !important;
+}
+
+.dashtopanelMainPanel .overview-tile, .dashtopanelMainPanel .grid-search-result {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .overview-tile .overview-icon, .dashtopanelMainPanel .grid-search-result .overview-icon {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .show-apps {
+  color: white !important;
+  border-radius: 0 !important;
+}
+
+.dashtopanelMainPanel .show-apps:hover {
+  background: rgba(255, 255, 255, 0.12) !important;
+}
+
+.dashtopanelMainPanel .show-apps:active {
+  background: rgba(255, 255, 255, 0.3) !important;
+}
+
+.dashtopanelMainPanel .panel-button, .dashtopanelMainPanel .panel-button.clock-display .clock {
+  border-radius: 8px !important;
+  margin: 0 !important;
+}
+
+.dashtopanelMainPanel .arcmenu-menu-button {
+  border-radius: 5px !important;
+  padding: 8px 6px !important;
+}
+
+.popup-menu.panel-menu .popup-menu-content, .popup-menu.panel-menu.quick-settings .popup-menu-content {
+  margin-bottom: 3px !important;
+}
+
+.dashtopanelSecondaryMenu {
+  border-radius: 12px !important;
+}
+
+#preview-menu {
+  margin: 6px !important;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2) !important;
+  border-radius: 12px !important;
+  padding: 0 !important;
+}
+
+#dashtopanelPreviewScrollview {
+  padding: 12px 0 !important;
+  border-radius: 12px !important;
+  background: #0c0c0c !important;
+}
+
+.openweather-button, .openweather-button-action, .openweather-menu-button-container, .openweather-button-box {
+  border: 1px solid transparent;
+}
+
+.openweather-provider {
+  padding: 0 16px;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.6);
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.openweather-provider:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.openweather-provider:focus {
+  color: rgba(0, 0, 0, 0.87);
+  text-shadow: none;
+  icon-shadow: none;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.openweather-provider:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.26);
+  border-color: transparent;
+  box-shadow: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+
+.openweather-current-icon, .openweather-current-summary, .openweather-current-summarybox {
+  background: none;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.openweather-current-databox-values {
+  background: none;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.openweather-current-databox-captions {
+  background: none;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.openweather-forecast-icon, .openweather-forecast-summary {
+  background: none;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.openweather-forecast-day, .openweather-forecast-temperature {
+  background: none;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.openweather-sunrise-icon, .openweather-sunset-icon, .openweather-build-icon {
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.popup-sub-menu .openweather-current-icon, .popup-sub-menu .openweather-current-summary, .popup-sub-menu .openweather-current-summarybox {
+  background: none;
+  color: rgba(0, 0, 0, 0.95);
+}
+
+.popup-sub-menu .openweather-current-databox-values {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.popup-sub-menu .openweather-current-databox-captions {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.popup-sub-menu .openweather-forecast-icon, .popup-sub-menu .openweather-forecast-summary {
+  color: rgba(0, 0, 0, 0.85);
+}
+
+.popup-sub-menu .openweather-forecast-day, .popup-sub-menu .openweather-forecast-temperature {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.popup-sub-menu .openweather-sunrise-icon, .popup-sub-menu .openweather-sunset-icon, .popup-sub-menu .openweather-build-icon {
+  color: rgba(0, 0, 0, 0.85);
+}
+
+.arcmenu-menu-button,
+.arcmenu-button {
+  border-width: 0 !important;
+  border-radius: 9999px !important;
+}
+
+.cosmic-solid-bg {
+  background-color: #242424;
+}
+
+.cosmic-dock #dock {
+  background-color: transparent;
+}
+
+.cosmic-dock #dock .dash-background {
+  background-color: rgba(33, 33, 33, 0.65);
+}
+
+.cosmic-dock.extended #dash {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding: 0 0;
+}
+
+.cosmic-dock.extended #dash .dash-background {
+  border-radius: 0;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.overview-components-transparent .search-entry,
+.overview-components-light .search-entry,
+.overview-components-dark .search-entry {
+  caret-color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.overview-components-transparent .search-entry .search-entry-icon,
+.overview-components-light .search-entry .search-entry-icon,
+.overview-components-dark .search-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.overview-components-transparent .search-entry StLabel.hint-text,
+.overview-components-light .search-entry StLabel.hint-text,
+.overview-components-dark .search-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.35) !important;
+}

--- a/src/gnome-shell/shell-48-0/gnome-shell.scss
+++ b/src/gnome-shell/shell-48-0/gnome-shell.scss
@@ -1,0 +1,10 @@
+$variant: 'light';
+$topbar: 'dark';
+$compact: 'false';
+
+@import '../../_sass/variables';
+@import '../../_sass/colors';
+@import '../../_sass/gnome-shell/drawing';
+@import '../../_sass/gnome-shell/common';
+@import '../../_sass/gnome-shell/widgets-48-0';
+@import '../../_sass/gnome-shell/extensions-46-0';


### PR DESCRIPTION
# **For a clean diff, see [marmitar/Orchis-theme#1](https://github.com/marmitar/Orchis-theme/pull/1/files)**

This is a fix for #514 and #516. The fix does work overall, but it has some coloring issues.

Any opinion or help here would be appreciated. You can find all changes for Gnome 48 themes on [this diff](https://gitlab.gnome.org/GNOME/gnome-shell/-/compare/47.0...48.0?from_project_id=546&page=6). The important file is `
src/_sass/gnome-shell/widgets/_quick-settings-48.scss`. My changes are on the last two `wip` commits.

## Visual Reference

Here's the base fix:

![Screenshot From 2025-03-22 20-02-48](https://github.com/user-attachments/assets/a5ba33af-2c18-41cb-b661-d3f2862e871d)

Notice that new separator there? I didn't know which color to use, so I removed it:

![Screenshot From 2025-03-22 20-05-37](https://github.com/user-attachments/assets/ac63e0d6-9fff-4bf9-aa4b-3919c993f8e4)

Here you can see that the arrow has a different background color from the button when unchecked, but the same color when checked. Since I don't know the colors used before, I decide to just use the button colors for everything. Here's how it looks:

![Screenshot From 2025-03-22 20-06-55](https://github.com/user-attachments/assets/4b84e947-b8a2-4fb7-ad4d-e8e1efe67eb1)

So that's the current state of this fix.