### PR TITLE
GTK-4.0: Reduce the `border-spacing` and `margin` for the `child box` within the `GridView`

### DIFF
--- a/src/_sass/gtk/_common-4.0.scss
+++ b/src/_sass/gtk/_common-4.0.scss
@@ -109,8 +109,8 @@ gridview {
     }
 
     box { //cells
-      border-spacing: 8px; //label separation
-      margin: 12px;
+      border-spacing: 2px; //label separation
+      margin: 3px;
     }
   }
 }


### PR DESCRIPTION
I use [Gapless](https://flathub.org/apps/com.github.neithern.g4music) on a daily basis. For a long time, I have had to manually make this change after installing the theme. Below is a comparison of the before and after:

Before:
![Screenshot From 2025-03-29 17-29-07](https://github.com/user-attachments/assets/9d45c0ff-2eff-4b2f-882b-267e965e3331)

After:
![Screenshot From 2025-03-29 17-28-41](https://github.com/user-attachments/assets/632acb7f-a26a-4642-a09f-2fa5c79bfe04)

This change significantly reduces wasted space. It seems uncommon to find an app that utilizes the `child box` within the `GridView`. Nevertheless, this change should benefit apps beyond just this particular one.