### PR TITLE
Adding window border, fix for workspace naming.

### DIFF
--- a/src/_sass/cinnamon/_common.scss
+++ b/src/_sass/cinnamon/_common.scss
@@ -563,9 +563,17 @@ $submenu_item_radius: $popup-radius - $space-size;
   }
 }
 
+.window-border {
+  border: 3px solid $primary;
+  border-radius: 10px;
+  background-color: rgba(255, 255, 255, 0.05);
+  /* Cover rounded corners and some bad adjustment gaps */
+  box-shadow: 0 0 0 1px $primary inset; 
+}
+
 .expo-workspaces-name-entry,
 .expo-workspaces-name-entry#selected {
-  height: 15px;
+  height: 12pt;
   border-radius: $corner-radius;
   font-size: 9pt;
   padding: 5px 8px;
@@ -573,12 +581,9 @@ $submenu_item_radius: $popup-radius - $space-size;
   @include entry(osd);
 
   &:focus {
-    border: 1px solid $primary;
-    background-color: $primary;
-    color: on($primary);
-    font-style: italic;
+    border: 2px solid $primary;
     transition-duration: 300;
-    selection-background-color: on($primary);
+    selection-background-color: $primary;
     selected-color: $primary;
   }
 }


### PR DESCRIPTION
I have noticed a couple of issues and I decided that I should try my bes to fix them:

1) You can't name a workspace outside of the active workspace if there are at least three workspaces
fix: The issue is due to inconsistent borders widths.

2) There isn't a good contrast while naming the workspace (my opinion)
fix: get rid of the :focus bg-color and add a border instead.

3) Window border border colors are not implemented causing an inconsistent look
before fix:
<img width="384" height="216" alt="Screenshot from 2025-07-20 15-26-57" src="https://github.com/user-attachments/assets/5e211c06-f2ee-4397-9e6a-30263ca1b253" />

after fix:
<img width="385" height="216" alt="Screenshot from 2025-07-20 15-27-27" src="https://github.com/user-attachments/assets/3964abde-84cf-47f7-98a1-722f0c518723" />


4) This is a little change but I changed the height of the name entry to create a more coherent ui. Plus the text is now properly aligned with the input.