### PR TITLE
fix: remove legacy mentions of deleted classes

### DIFF
--- a/src/_sass/gtk/_common-3.20.scss
+++ b/src/_sass/gtk/_common-3.20.scss
@@ -1227,9 +1227,9 @@ searchbar > revealer > box {
       padding-left: ($medium-size - 24px) / 2;
       padding-right: ($medium-size - 24px) / 2;
     }
-  
+
     &:focus, &:hover, &:active, &:checked { color: $titlebar-text; }
-  
+
     &:disabled { color: $titlebar-text-secondary-disabled; }
   }
 
@@ -3535,7 +3535,7 @@ separator.sidebar {
  * File chooser *
  ****************/
 // dim the sidebar icons, see bug #786613 for details on this oddity
-row image.sidebar-icon {
+row image {
   transition: color $duration $ease-out;
   color: $text-secondary;
 
@@ -3563,17 +3563,17 @@ placessidebar.sidebar {
       color: $primary;
       font-weight: 500;
 
-      image.sidebar-icon { color: $primary; }
+      image { color: $primary; }
     }
 
     &:disabled { color: $text-disabled; }
 
-    image.sidebar-icon {
+    image {
       &:dir(ltr) { padding-right: 8px; }
       &:dir(rtl) { padding-left: 8px; }
     }
 
-    label.sidebar-label {
+    label {
       color: inherit;
 
       &:dir(ltr) { padding-right: 2px; }
@@ -3590,7 +3590,7 @@ placessidebar.sidebar {
     &.sidebar-new-bookmark-row {
       color: $primary;
 
-      image.sidebar-icon { color: $primary; }
+      image { color: $primary; }
     }
 
     &:drop(active) {

--- a/src/_sass/gtk/_common-4.0.scss
+++ b/src/_sass/gtk/_common-4.0.scss
@@ -359,7 +359,7 @@ entry {
         > placeholder {
           color: rgba($e_color, 0.35);
         }
-    
+
         > block-cursor {
           color: $e_color;
           background-color: on($e_color);
@@ -1243,7 +1243,7 @@ headerbar {
     .subtitle,
     .dim-label {
       color: $text-secondary;
-  
+
       &:backdrop { color: $text-disabled; }
     }
 
@@ -3509,7 +3509,7 @@ row {
     > .suffixes {
       border-spacing: $space-size;
     }
-  
+
     > .icon,
     > .prefixes {
       &:dir(ltr) { margin-right: $space-size; }
@@ -4151,7 +4151,7 @@ window.about {
 
   headerbar {
     color: $text-secondary;
-    
+
     &, &:backdrop {
       background-color: transparent;
       box-shadow: inset 0 1px highlight($titlebar);
@@ -4331,12 +4331,12 @@ placessidebar {
 
       &:disabled { color: $text-disabled; }
 
-      image.sidebar-icon {
+      image {
         &:dir(ltr) { padding-right: 8px; }
         &:dir(rtl) { padding-left: 8px; }
       }
 
-      label.sidebar-label {
+      label {
         color: inherit;
 
         &:dir(ltr) { padding-right: 2px; }
@@ -4728,7 +4728,7 @@ window {
     @if $variant == 'light' and $topbar == 'dark' {
       &.about, &.messagedialog, &.message {
         box-shadow: $shadow-z16, 0 16px 16px 2px transparent, 0 6px 18px 5px transparent;
-  
+
         &:backdrop {
           box-shadow: $shadow-z4, 0 16px 16px 2px transparent, 0 6px 18px 5px transparent;
         }
@@ -4743,7 +4743,7 @@ window {
       border-radius: 0;
       outline: none;
     }
-  
+
     &.maximized,
     &.fullscreen {
       border-radius: 0;

--- a/src/_sass/gtk/apps/_gnome-3.22.scss
+++ b/src/_sass/gtk/apps/_gnome-3.22.scss
@@ -51,15 +51,15 @@ $theme_list_radius: $window-radius - $space-size;
               animation: none;
             }
 
-            &, image.sidebar-icon, label.sidebar-label {
+            &, image, label {
               color: $titlebar-text-secondary;
             }
 
-            image.sidebar-icon {
+            image {
               padding-right: $space-size;
             }
 
-            label.sidebar-label {
+            label {
               color: inherit;
               min-height: 54px;
               padding: 0 0 0 $space-size;
@@ -86,7 +86,7 @@ $theme_list_radius: $window-radius - $space-size;
 
               background-color: rgba($drop_target_color, 0.1);
 
-              &, image.sidebar-icon, label.sidebar-label {
+              &, image, label {
                 color: $drop_target_color;
               }
             }
@@ -96,7 +96,7 @@ $theme_list_radius: $window-radius - $space-size;
             }
 
             &:hover {
-              image.sidebar-icon, label.sidebar-label { color: $primary; }
+              image, label { color: $primary; }
             }
 
             &:selected {
@@ -104,7 +104,7 @@ $theme_list_radius: $window-radius - $space-size;
               font-weight: 700;
               // font-size: larger;
 
-              image.sidebar-icon, label.sidebar-label { color: $primary; }
+              image, label { color: $primary; }
 
               > revealer.sidebar-revealer > widget > box {
                 background-color: $base;
@@ -114,7 +114,7 @@ $theme_list_radius: $window-radius - $space-size;
                 border-image-source: -gtk-scaled(url("assets/row-selected#{$blackness-asset-suffix}#{$theme-asset-suffix}.png"),
                                                  url("assets/row-selected#{$blackness-asset-suffix}#{$theme-asset-suffix}@2.png"));
 
-                label.sidebar-label {
+                label {
                   padding-left: 14px;
                 }
               }
@@ -127,7 +127,7 @@ $theme_list_radius: $window-radius - $space-size;
             }
 
             &:disabled {
-              &, image.sidebar-icon, label.sidebar-label {
+              &, image, label {
                 color: $titlebar-text-secondary-disabled;
               }
             }

--- a/src/_sass/gtk/apps/_gnome-4.0.scss
+++ b/src/_sass/gtk/apps/_gnome-4.0.scss
@@ -257,15 +257,15 @@
               animation: none;
             }
 
-            &, image.sidebar-icon, label.sidebar-label {
+            &, image, label {
               color: $titlebar-text-secondary;
             }
 
-            image.sidebar-icon {
+            image {
               padding-right: $space-size;
             }
 
-            label.sidebar-label {
+            label {
               color: inherit;
               min-height: 54px;
               padding-left: $space-size;
@@ -284,7 +284,7 @@
 
               background-color: rgba($drop_target_color, 0.1);
 
-              &, image.sidebar-icon, label.sidebar-label {
+              &, image, label {
                 color: $drop_target_color;
               }
             }
@@ -296,7 +296,7 @@
             }
 
             &:hover {
-              image.sidebar-icon, label.sidebar-label {
+              image, label {
                 color: $primary;
               }
             }
@@ -306,11 +306,11 @@
               font-weight: 700;
               // font-size: larger;
 
-              image.sidebar-icon {
+              image {
                 color: $primary;
               }
 
-              image.sidebar-icon, label.sidebar-label {
+              image, label {
                 color: $primary;
               }
 
@@ -331,7 +331,7 @@
                   url("assets/row-selected#{$blackness-asset-suffix}#{$theme-asset-suffix}@2.png"));
               }
 
-              label.sidebar-label {
+              label {
                 margin-left: $space-size + 4px;
               }
 
@@ -343,7 +343,7 @@
             }
 
             &:disabled {
-              &, image.sidebar-icon, label.sidebar-label {
+              &, image, label {
                 color: $titlebar-text-secondary-disabled;
               }
             }


### PR DESCRIPTION
Gnome 50 seem to have removed two classes .sidebar-label and .sidebar-icon which breaks the sidebar.

Removing mentions of those classes is an easy fix for the sidebar although I am not 100% that it will fix every issues of this nature.

This should fix those issues :
 - https://github.com/vinceliuice/Orchis-theme/issues/595
 - https://github.com/vinceliuice/Orchis-theme/issues/594